### PR TITLE
Update Softvector load/store interface and RVV architecture

### DIFF
--- a/ArchImpl/RV32IMACFDV/CMakeLists.txt
+++ b/ArchImpl/RV32IMACFDV/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+# Generated on Mon, 20 Jan 2025 16:02:49 +0000.
 #
 # This file contains the CMake build info for the RV32IMACFDV core architecture.
 

--- a/ArchImpl/RV32IMACFDV/CMakeLists.txt
+++ b/ArchImpl/RV32IMACFDV/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+# Generated on Tue, 04 Mar 2025 12:00:03 +0000.
 #
 # This file contains the CMake build info for the RV32IMACFDV core architecture.
 

--- a/ArchImpl/RV32IMACFDV/CMakeLists.txt
+++ b/ArchImpl/RV32IMACFDV/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+# Generated on Tue, 21 Jan 2025 11:58:28 +0000.
 #
 # This file contains the CMake build info for the RV32IMACFDV core architecture.
 

--- a/ArchImpl/RV32IMACFDV/CMakeLists.txt
+++ b/ArchImpl/RV32IMACFDV/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+# Generated on Wed, 05 Feb 2025 11:38:08 +0000.
 #
 # This file contains the CMake build info for the RV32IMACFDV core architecture.
 
@@ -18,8 +18,8 @@ ADD_LIBRARY(${PROJECT_NAME} SHARED
 	RV32IMACFDV_RV32MInstr.cpp
 	RV32IMACFDV_RVZve32xInstr.cpp
 	RV32IMACFDV_RVZve64xInstr.cpp
-	RV32IMACFDV_RVZve32fInstr.cpp
 	RV32IMACFDV_RV32FInstr.cpp
+	RV32IMACFDV_RVZve32fInstr.cpp
 	RV32IMACFDV_RV32FCInstr.cpp
 	RV32IMACFDV_RV32DInstr.cpp
 	RV32IMACFDV_RV32DCInstr.cpp

--- a/ArchImpl/RV32IMACFDV/CMakeLists.txt
+++ b/ArchImpl/RV32IMACFDV/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+# Generated on Wed, 05 Feb 2025 12:27:46 +0000.
 #
 # This file contains the CMake build info for the RV32IMACFDV core architecture.
 

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVArch.h
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVArch.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the architecture class for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVArch.h
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVArch.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the architecture class for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVArch.h
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVArch.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the architecture class for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVArch.h
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVArch.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the architecture class for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVArch.h
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVArch.h
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the architecture class for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVArchLib.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVArchLib.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the library interface for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVArchLib.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVArchLib.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the library interface for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVArchLib.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVArchLib.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the library interface for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVArchLib.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVArchLib.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the library interface for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVArchLib.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVArchLib.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the library interface for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVFuncs.c
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVFuncs.c
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the function implementations for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVFuncs.c
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVFuncs.c
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the function implementations for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVFuncs.c
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVFuncs.c
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the function implementations for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVFuncs.c
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVFuncs.c
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the function implementations for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVFuncs.c
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVFuncs.c
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the function implementations for the RV32IMACFDV core architecture.
  */

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the default
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the default
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the default
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the default
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDVInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDVInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the default
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32AInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32AInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the RV32A
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32AInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32AInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the RV32A
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32AInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32AInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the RV32A
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32AInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32AInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the RV32A
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32AInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32AInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the RV32A
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DCInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the RV32DC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DCInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the RV32DC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DCInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the RV32DC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DCInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the RV32DC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DCInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the RV32DC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the RV32D
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the RV32D
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the RV32D
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the RV32D
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32DInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the RV32D
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FCInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the RV32FC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FCInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the RV32FC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FCInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the RV32FC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FCInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the RV32FC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FCInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FCInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the RV32FC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the RV32F
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the RV32F
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the RV32F
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the RV32F
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32FInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the RV32F
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32ICInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32ICInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the RV32IC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32ICInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32ICInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the RV32IC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32ICInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32ICInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the RV32IC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32ICInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32ICInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the RV32IC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32ICInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32ICInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the RV32IC
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32IInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32IInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the RV32I
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32IInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32IInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the RV32I
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32IInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32IInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the RV32I
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32IInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32IInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the RV32I
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32IInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32IInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the RV32I
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32MInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32MInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the RV32M
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32MInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32MInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the RV32M
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32MInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32MInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the RV32M
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32MInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32MInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the RV32M
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32MInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RV32MInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the RV32M
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32fInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32fInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the RVZve32f
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32fInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32fInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the RVZve32f
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32fInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32fInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the RVZve32f
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32fInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32fInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the RVZve32f
  * instruction set for the RV32IMACFDV core architecture.
@@ -5230,7 +5230,7 @@ ss << "vfsqrt_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | vs2=" + s
 static InstructionDefinition vfrsqrt7_v_vd_vs2_vm (
 	ISA32_RV32IMACFDV,
 	"vfrsqrt7_v",
-	(uint32_t) 0xfc021057,
+	(uint32_t) 0x4c021057,
 	(uint32_t) 0xfc0ff07f,
 	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
 	{
@@ -5340,7 +5340,7 @@ ss << "vfrsqrt7_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | vs2=" +
 static InstructionDefinition vfrec7_v_vd_vs2_vm (
 	ISA32_RV32IMACFDV,
 	"vfrec7_v",
-	(uint32_t) 0xfc029057,
+	(uint32_t) 0x4c029057,
 	(uint32_t) 0xfc0ff07f,
 	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
 	{
@@ -11089,6 +11089,434 @@ vm += R_vm_0.read(ba) << 0;
 		std::stringstream ss;
 // -----------------------------------------------------------------------------
 ss << "vfwredusum_vs" << " # " << ba << (" [vd=" + std::to_string(vd) + " | vs1=" + std::to_string(vs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VFMV_F_S --------------------------------------------------------------------
+static InstructionDefinition vfmv_f_s_rd_vs2 (
+	ISA32_RV32IMACFDV,
+	"vfmv_f_s",
+	(uint32_t) 0x42001057,
+	(uint32_t) 0xfe0ff07f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 rd = 0;
+static BitArrayRange R_rd_0(11, 7);
+rd += R_rd_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VFMV_F_S\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = vfmv_f_s(((RV32IMACFDV*)cpu)->V, *((RV32IMACFDV*)cpu)->F, _vtype, " + std::to_string(rd) + "ULL, " + std::to_string(vs2) + "ULL, _vstart, _vlen, _vl, 64ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VFMV_F_S\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 rd = 0;
+static BitArrayRange R_rd_0(11, 7);
+rd += R_rd_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vfmv_f_s" << " # " << ba << (" [rd=" + std::to_string(rd) + " | vs2=" + std::to_string(vs2) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VFMV_S_F --------------------------------------------------------------------
+static InstructionDefinition vfmv_s_f_vd_rs1 (
+	ISA32_RV32IMACFDV,
+	"vfmv_s_f",
+	(uint32_t) 0x42005057,
+	(uint32_t) 0xfff0707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VFMV_S_F\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = vfmv_s_f(((RV32IMACFDV*)cpu)->V, *((RV32IMACFDV*)cpu)->F, _vtype, " + std::to_string(vd) + "ULL, " + std::to_string(rs1) + "ULL, _vstart, _vlen, _vl, 64ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VFMV_S_F\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vfmv_s_f" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VFSLIDE1UP_VX ---------------------------------------------------------------
+static InstructionDefinition vfslide1up_vx_vd_rs1_vs2_vm (
+	ISA32_RV32IMACFDV,
+	"vfslide1up_vx",
+	(uint32_t) 0x38005057,
+	(uint32_t) 0xfc00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VFSLIDE1UP_VX\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = vfslide1up_vf(((RV32IMACFDV*)cpu)->V, *((RV32IMACFDV*)cpu)->F, _vtype, " + std::to_string(vm) + "ULL, " + std::to_string(vd) + "ULL, " + std::to_string(vs2) + "ULL, " + std::to_string(rs1) + "ULL, _vstart, _vlen, _vl, 64ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VFSLIDE1UP_VX\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vfslide1up_vx" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VFSLIDE1DOWN_VF -------------------------------------------------------------
+static InstructionDefinition vfslide1down_vf_vd_rs1_vs2_vm (
+	ISA32_RV32IMACFDV,
+	"vfslide1down_vf",
+	(uint32_t) 0x3c005057,
+	(uint32_t) 0xfc00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VFSLIDE1DOWN_VF\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = vfslide1down_vf(((RV32IMACFDV*)cpu)->V, *((RV32IMACFDV*)cpu)->F, _vtype, " + std::to_string(vm) + "ULL, " + std::to_string(vd) + "ULL, " + std::to_string(vs2) + "ULL, " + std::to_string(rs1) + "ULL, _vstart, _vlen, _vl, 64ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VFSLIDE1DOWN_VF\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vfslide1down_vf" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
 // -----------------------------------------------------------------------------
 		return ss.str();
 	}

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32fInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32fInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the RVZve32f
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32xInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32xInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the RVZve32x
  * instruction set for the RV32IMACFDV core architecture.
@@ -206,7 +206,7 @@ ss << "vsetvli" << " # " << ba << (" [rd=" + std::to_string(rd) + " | rs1=" + st
 );
 
 // VSETIVLI --------------------------------------------------------------------
-static InstructionDefinition vsetivli_rd_uimm_zimm (
+static InstructionDefinition vsetivli_rd_uimm_vtypei (
 	ISA32_RV32IMACFDV,
 	"vsetivli",
 	(uint32_t) 0xc0007057,
@@ -225,9 +225,9 @@ rd += R_rd_0.read(ba) << 0;
 etiss_uint8 uimm = 0;
 static BitArrayRange R_uimm_0(19, 15);
 uimm += R_uimm_0.read(ba) << 0;
-etiss_uint16 zimm = 0;
-static BitArrayRange R_zimm_0(29, 20);
-zimm += R_zimm_0.read(ba) << 0;
+etiss_uint16 vtypei = 0;
+static BitArrayRange R_vtypei_0(29, 20);
+vtypei += R_vtypei_0.read(ba) << 0;
 
 // -----------------------------------------------------------------------------
 
@@ -244,7 +244,114 @@ cp.code() += "} // block\n";
 } // block
 { // block
 cp.code() += "{ // block\n";
-etiss_uint32 _vlmax = 0LL;
+cp.code() += "etiss_uint8 sew = (vtype_extractSEW(" + std::to_string(vtypei) + "ULL)) & 0x7;\n";
+cp.code() += "etiss_uint8 lmul = (vtype_extractLMUL(" + std::to_string(vtypei) + "ULL)) & 0x7;\n";
+cp.code() += "etiss_uint8 vta = (vtype_extractTA(" + std::to_string(vtypei) + "ULL)) & 0x1;\n";
+cp.code() += "etiss_uint8 vma = (vtype_extractMA(" + std::to_string(vtypei) + "ULL)) & 0x1;\n";
+cp.code() += "etiss_uint32 _vlmax = 0LL;\n";
+cp.code() += "etiss_uint32 _vtype_result = " + std::to_string(vtypei) + "ULL;\n";
+cp.code() += "etiss_uint32 vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "if (sew == 3ULL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "_vtype_result = 2147483648ULL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "if (lmul & 4ULL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "if (lmul == 6ULL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "_vlmax = vlen / (8ULL << sew) / 4ULL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += " else if (lmul == 7ULL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "_vlmax = vlen / (8ULL << sew) / 2ULL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "_vtype_result = 2147483648ULL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "if (lmul == 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "_vlmax = vlen / (8ULL << sew);\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += " else if (lmul == 1ULL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "_vlmax = vlen / (8ULL << sew) * 2ULL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += " else if (lmul == 2ULL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "_vlmax = vlen / (8ULL << sew) * 4ULL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += " else if (lmul == 3ULL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "_vlmax = vlen / (8ULL << sew) * 8ULL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+etiss_uint32 _avl = uimm;
+cp.code() += "etiss_uint32 _vl = 0LL;\n";
+cp.code() += "if (" + std::to_string(_avl) + "ULL <= _vlmax) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "_vl = " + std::to_string(_avl) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += " else if (" + std::to_string(_avl) + "ULL >= (2ULL * _vlmax)) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "_vl = _vlmax;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "_vl = _vlmax;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[3104ULL] = _vl;\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[3105ULL] = _vtype_result;\n";
+if (rd != 0LL) { // conditional
+cp.code() += "*((RV32IMACFDV*)cpu)->X[" + std::to_string(rd) + "ULL] = _vl;\n";
+} // conditional
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
@@ -265,15 +372,15 @@ rd += R_rd_0.read(ba) << 0;
 etiss_uint8 uimm = 0;
 static BitArrayRange R_uimm_0(19, 15);
 uimm += R_uimm_0.read(ba) << 0;
-etiss_uint16 zimm = 0;
-static BitArrayRange R_zimm_0(29, 20);
-zimm += R_zimm_0.read(ba) << 0;
+etiss_uint16 vtypei = 0;
+static BitArrayRange R_vtypei_0(29, 20);
+vtypei += R_vtypei_0.read(ba) << 0;
 
 // -----------------------------------------------------------------------------
 
 		std::stringstream ss;
 // -----------------------------------------------------------------------------
-ss << "vsetivli" << " # " << ba << (" [rd=" + std::to_string(rd) + " | uimm=" + std::to_string(uimm) + " | zimm=" + std::to_string(zimm) + "]");
+ss << "vsetivli" << " # " << ba << (" [rd=" + std::to_string(rd) + " | uimm=" + std::to_string(uimm) + " | vtypei=" + std::to_string(vtypei) + "]");
 // -----------------------------------------------------------------------------
 		return ss.str();
 	}
@@ -468,8774 +575,6 @@ rs2 += R_rs2_0.read(ba) << 0;
 		std::stringstream ss;
 // -----------------------------------------------------------------------------
 ss << "vsetvl" << " # " << ba << (" [rd=" + std::to_string(rd) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VS1R_V ----------------------------------------------------------------------
-static InstructionDefinition vs1r_v_vs3_rs1 (
-	ISA32_RV32IMACFDV,
-	"vs1r_v",
-	(uint32_t) 0x2800027,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VS1R_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vs1r_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VS2R_V ----------------------------------------------------------------------
-static InstructionDefinition vs2r_v_vs3_rs1 (
-	ISA32_RV32IMACFDV,
-	"vs2r_v",
-	(uint32_t) 0x22800027,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VS2R_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vs2r_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VS4R_V ----------------------------------------------------------------------
-static InstructionDefinition vs4r_v_vs3_rs1 (
-	ISA32_RV32IMACFDV,
-	"vs4r_v",
-	(uint32_t) 0x62800027,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VS4R_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vs4r_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VS8R_V ----------------------------------------------------------------------
-static InstructionDefinition vs8r_v_vs3_rs1 (
-	ISA32_RV32IMACFDV,
-	"vs8r_v",
-	(uint32_t) 0xe2800027,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VS8R_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vs8r_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG2EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsoxseg2ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg2ei8_v",
-	(uint32_t) 0x2c000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG2EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg2ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG2EI16_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg2ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg2ei16_v",
-	(uint32_t) 0x2c005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG2EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg2ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG2EI32_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg2ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg2ei32_v",
-	(uint32_t) 0x2c006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG2EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg2ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG3EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsoxseg3ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg3ei8_v",
-	(uint32_t) 0x4c000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG3EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg3ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG3EI16_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg3ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg3ei16_v",
-	(uint32_t) 0x4c005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG3EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg3ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG3EI32_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg3ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg3ei32_v",
-	(uint32_t) 0x4c006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG3EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg3ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG4EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsoxseg4ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg4ei8_v",
-	(uint32_t) 0x6c000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG4EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg4ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG4EI16_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg4ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg4ei16_v",
-	(uint32_t) 0x6c005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG4EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg4ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG4EI32_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg4ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg4ei32_v",
-	(uint32_t) 0x6c006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG4EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg4ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG5EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsoxseg5ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg5ei8_v",
-	(uint32_t) 0x8c000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG5EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg5ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG5EI16_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg5ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg5ei16_v",
-	(uint32_t) 0x8c005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG5EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg5ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG5EI32_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg5ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg5ei32_v",
-	(uint32_t) 0x8c006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG5EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg5ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG6EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsoxseg6ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg6ei8_v",
-	(uint32_t) 0xac000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG6EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg6ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG6EI16_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg6ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg6ei16_v",
-	(uint32_t) 0xac005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG6EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg6ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG6EI32_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg6ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg6ei32_v",
-	(uint32_t) 0xac006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG6EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg6ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG7EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsoxseg7ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg7ei8_v",
-	(uint32_t) 0xcc000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG7EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg7ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG7EI16_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg7ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg7ei16_v",
-	(uint32_t) 0xcc005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG7EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg7ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG7EI32_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg7ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg7ei32_v",
-	(uint32_t) 0xcc006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG7EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg7ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG8EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsoxseg8ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg8ei8_v",
-	(uint32_t) 0xec000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG8EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg8ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG8EI16_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg8ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg8ei16_v",
-	(uint32_t) 0xec005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG8EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg8ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXSEG8EI32_V --------------------------------------------------------------
-static InstructionDefinition vsoxseg8ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxseg8ei32_v",
-	(uint32_t) 0xec006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXSEG8EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxseg8ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG2EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsuxseg2ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg2ei8_v",
-	(uint32_t) 0x24000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG2EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg2ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG2EI16_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg2ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg2ei16_v",
-	(uint32_t) 0x24005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG2EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg2ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG2EI32_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg2ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg2ei32_v",
-	(uint32_t) 0x24006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG2EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg2ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG3EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsuxseg3ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg3ei8_v",
-	(uint32_t) 0x44000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG3EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg3ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG3EI16_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg3ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg3ei16_v",
-	(uint32_t) 0x44005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG3EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg3ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG3EI32_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg3ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg3ei32_v",
-	(uint32_t) 0x44006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG3EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg3ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG4EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsuxseg4ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg4ei8_v",
-	(uint32_t) 0x64000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG4EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg4ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG4EI16_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg4ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg4ei16_v",
-	(uint32_t) 0x64005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG4EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg4ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG4EI32_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg4ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg4ei32_v",
-	(uint32_t) 0x64006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG4EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg4ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG5EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsuxseg5ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg5ei8_v",
-	(uint32_t) 0x84000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG5EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg5ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG5EI16_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg5ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg5ei16_v",
-	(uint32_t) 0x84005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG5EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg5ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG5EI32_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg5ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg5ei32_v",
-	(uint32_t) 0x84006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG5EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg5ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG6EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsuxseg6ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg6ei8_v",
-	(uint32_t) 0xa4000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG6EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg6ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG6EI16_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg6ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg6ei16_v",
-	(uint32_t) 0xa4005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG6EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg6ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG6EI32_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg6ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg6ei32_v",
-	(uint32_t) 0xa4006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG6EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg6ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG7EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsuxseg7ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg7ei8_v",
-	(uint32_t) 0xc4000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG7EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg7ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG7EI16_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg7ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg7ei16_v",
-	(uint32_t) 0xc4005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG7EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg7ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG7EI32_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg7ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg7ei32_v",
-	(uint32_t) 0xc4006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG7EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg7ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG8EI8_V ---------------------------------------------------------------
-static InstructionDefinition vsuxseg8ei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg8ei8_v",
-	(uint32_t) 0xe4000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG8EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg8ei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG8EI16_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg8ei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg8ei16_v",
-	(uint32_t) 0xe4005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG8EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg8ei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXSEG8EI32_V --------------------------------------------------------------
-static InstructionDefinition vsuxseg8ei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxseg8ei32_v",
-	(uint32_t) 0xe4006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXSEG8EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxseg8ei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG2EI8_V ---------------------------------------------------------------
-static InstructionDefinition vloxseg2ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg2ei8_v",
-	(uint32_t) 0x2c000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG2EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg2ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG2EI16_V --------------------------------------------------------------
-static InstructionDefinition vloxseg2ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg2ei16_v",
-	(uint32_t) 0x2c005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG2EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg2ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG2EI32_V --------------------------------------------------------------
-static InstructionDefinition vloxseg2ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg2ei32_v",
-	(uint32_t) 0x2c006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG2EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg2ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG3EI8_V ---------------------------------------------------------------
-static InstructionDefinition vloxseg3ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg3ei8_v",
-	(uint32_t) 0x4c000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG3EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg3ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG3EI16_V --------------------------------------------------------------
-static InstructionDefinition vloxseg3ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg3ei16_v",
-	(uint32_t) 0x4c005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG3EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg3ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG3EI32_V --------------------------------------------------------------
-static InstructionDefinition vloxseg3ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg3ei32_v",
-	(uint32_t) 0x4c006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG3EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg3ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG4EI8_V ---------------------------------------------------------------
-static InstructionDefinition vloxseg4ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg4ei8_v",
-	(uint32_t) 0x6c000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG4EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg4ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG4EI16_V --------------------------------------------------------------
-static InstructionDefinition vloxseg4ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg4ei16_v",
-	(uint32_t) 0x6c005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG4EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg4ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG4EI32_V --------------------------------------------------------------
-static InstructionDefinition vloxseg4ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg4ei32_v",
-	(uint32_t) 0x6c006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG4EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg4ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG6EI8_V ---------------------------------------------------------------
-static InstructionDefinition vloxseg6ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg6ei8_v",
-	(uint32_t) 0xac000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG6EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg6ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG6EI16_V --------------------------------------------------------------
-static InstructionDefinition vloxseg6ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg6ei16_v",
-	(uint32_t) 0xac005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG6EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg6ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG6EI32_V --------------------------------------------------------------
-static InstructionDefinition vloxseg6ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg6ei32_v",
-	(uint32_t) 0xac006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG6EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg6ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG5EI8_V ---------------------------------------------------------------
-static InstructionDefinition vloxseg5ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg5ei8_v",
-	(uint32_t) 0x8c000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG5EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg5ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG5EI16_V --------------------------------------------------------------
-static InstructionDefinition vloxseg5ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg5ei16_v",
-	(uint32_t) 0x8c005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG5EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg5ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG5EI32_V --------------------------------------------------------------
-static InstructionDefinition vloxseg5ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg5ei32_v",
-	(uint32_t) 0x8c006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG5EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg5ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG8EI8_V ---------------------------------------------------------------
-static InstructionDefinition vloxseg8ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg8ei8_v",
-	(uint32_t) 0xec000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG8EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg8ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG8EI16_V --------------------------------------------------------------
-static InstructionDefinition vloxseg8ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg8ei16_v",
-	(uint32_t) 0xec005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG8EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg8ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG8EI32_V --------------------------------------------------------------
-static InstructionDefinition vloxseg8ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg8ei32_v",
-	(uint32_t) 0xec006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG8EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg8ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG3EI8_V ---------------------------------------------------------------
-static InstructionDefinition vluxseg3ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg3ei8_v",
-	(uint32_t) 0x44000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG3EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg3ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG3EI16_V --------------------------------------------------------------
-static InstructionDefinition vluxseg3ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg3ei16_v",
-	(uint32_t) 0x44005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG3EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg3ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG3EI32_V --------------------------------------------------------------
-static InstructionDefinition vluxseg3ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg3ei32_v",
-	(uint32_t) 0x44006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG3EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg3ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG2EI8_V ---------------------------------------------------------------
-static InstructionDefinition vluxseg2ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg2ei8_v",
-	(uint32_t) 0x24000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG2EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg2ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG2EI16_V --------------------------------------------------------------
-static InstructionDefinition vluxseg2ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg2ei16_v",
-	(uint32_t) 0x24005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG2EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg2ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG2EI32_V --------------------------------------------------------------
-static InstructionDefinition vluxseg2ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg2ei32_v",
-	(uint32_t) 0x24006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG2EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg2ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG4EI8_V ---------------------------------------------------------------
-static InstructionDefinition vluxseg4ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg4ei8_v",
-	(uint32_t) 0x64000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG4EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg4ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG4EI16_V --------------------------------------------------------------
-static InstructionDefinition vluxseg4ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg4ei16_v",
-	(uint32_t) 0x64005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG4EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg4ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG4EI32_V --------------------------------------------------------------
-static InstructionDefinition vluxseg4ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg4ei32_v",
-	(uint32_t) 0x64006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG4EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg4ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG5EI8_V ---------------------------------------------------------------
-static InstructionDefinition vluxseg5ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg5ei8_v",
-	(uint32_t) 0x84000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG5EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg5ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG5EI16_V --------------------------------------------------------------
-static InstructionDefinition vluxseg5ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg5ei16_v",
-	(uint32_t) 0x84005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG5EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg5ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG5EI32_V --------------------------------------------------------------
-static InstructionDefinition vluxseg5ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg5ei32_v",
-	(uint32_t) 0x84006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG5EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg5ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG6EI8_V ---------------------------------------------------------------
-static InstructionDefinition vluxseg6ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg6ei8_v",
-	(uint32_t) 0xa4000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG6EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg6ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG6EI16_V --------------------------------------------------------------
-static InstructionDefinition vluxseg6ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg6ei16_v",
-	(uint32_t) 0xa4005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG6EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg6ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG6EI32_V --------------------------------------------------------------
-static InstructionDefinition vluxseg6ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg6ei32_v",
-	(uint32_t) 0xa4006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG6EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg6ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG7EI8_V ---------------------------------------------------------------
-static InstructionDefinition vloxseg7ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg7ei8_v",
-	(uint32_t) 0xcc000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG7EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg7ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG7EI16_V --------------------------------------------------------------
-static InstructionDefinition vloxseg7ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg7ei16_v",
-	(uint32_t) 0xcc005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG7EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg7ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXSEG7EI32_V --------------------------------------------------------------
-static InstructionDefinition vloxseg7ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxseg7ei32_v",
-	(uint32_t) 0xcc006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXSEG7EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxseg7ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG7EI8_V ---------------------------------------------------------------
-static InstructionDefinition vluxseg7ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg7ei8_v",
-	(uint32_t) 0xc4000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG7EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg7ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG7EI16_V --------------------------------------------------------------
-static InstructionDefinition vluxseg7ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg7ei16_v",
-	(uint32_t) 0xc4005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG7EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg7ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG7EI32_V --------------------------------------------------------------
-static InstructionDefinition vluxseg7ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg7ei32_v",
-	(uint32_t) 0xc4006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG7EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg7ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG8EI8_V ---------------------------------------------------------------
-static InstructionDefinition vluxseg8ei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg8ei8_v",
-	(uint32_t) 0xe4000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG8EI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg8ei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG8EI16_V --------------------------------------------------------------
-static InstructionDefinition vluxseg8ei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg8ei16_v",
-	(uint32_t) 0xe4005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG8EI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg8ei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXSEG8EI32_V --------------------------------------------------------------
-static InstructionDefinition vluxseg8ei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxseg8ei32_v",
-	(uint32_t) 0xe4006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXSEG8EI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxseg8ei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXEI8_V -------------------------------------------------------------------
-static InstructionDefinition vsoxei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxei8_v",
-	(uint32_t) 0xc000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXEI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXEI16_V ------------------------------------------------------------------
-static InstructionDefinition vsoxei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxei16_v",
-	(uint32_t) 0xc005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXEI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSOXEI32_V ------------------------------------------------------------------
-static InstructionDefinition vsoxei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsoxei32_v",
-	(uint32_t) 0xc006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSOXEI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsoxei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXEI8_V -------------------------------------------------------------------
-static InstructionDefinition vsuxei8_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxei8_v",
-	(uint32_t) 0x4000027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXEI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXEI16_V ------------------------------------------------------------------
-static InstructionDefinition vsuxei16_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxei16_v",
-	(uint32_t) 0x4005027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXEI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSUXEI32_V ------------------------------------------------------------------
-static InstructionDefinition vsuxei32_v_vs3_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vsuxei32_v",
-	(uint32_t) 0x4006027,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSUXEI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsuxei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXEI8_V -------------------------------------------------------------------
-static InstructionDefinition vloxei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxei8_v",
-	(uint32_t) 0xc000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXEI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXEI16_V ------------------------------------------------------------------
-static InstructionDefinition vloxei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxei16_v",
-	(uint32_t) 0xc005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXEI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLOXEI32_V ------------------------------------------------------------------
-static InstructionDefinition vloxei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vloxei32_v",
-	(uint32_t) 0xc006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLOXEI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vloxei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXEI8_V -------------------------------------------------------------------
-static InstructionDefinition vluxei8_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxei8_v",
-	(uint32_t) 0x4000007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXEI8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXEI16_V ------------------------------------------------------------------
-static InstructionDefinition vluxei16_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxei16_v",
-	(uint32_t) 0x4005007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXEI16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLUXEI32_V ------------------------------------------------------------------
-static InstructionDefinition vluxei32_v_vd_rs1_vs2_vm (
-	ISA32_RV32IMACFDV,
-	"vluxei32_v",
-	(uint32_t) 0x4006007,
-	(uint32_t) 0xfc00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLUXEI32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vs2 = 0;
-static BitArrayRange R_vs2_0(24, 20);
-vs2 += R_vs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vluxei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VL1RE8_V --------------------------------------------------------------------
-static InstructionDefinition vl1re8_v_vd_rs1 (
-	ISA32_RV32IMACFDV,
-	"vl1re8_v",
-	(uint32_t) 0x2800007,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VL1RE8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vl1re8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VL2RE8_V --------------------------------------------------------------------
-static InstructionDefinition vl2re8_v_vd_rs1 (
-	ISA32_RV32IMACFDV,
-	"vl2re8_v",
-	(uint32_t) 0x22800007,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VL2RE8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vl2re8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VL4RE8_V --------------------------------------------------------------------
-static InstructionDefinition vl4re8_v_vd_rs1 (
-	ISA32_RV32IMACFDV,
-	"vl4re8_v",
-	(uint32_t) 0x62800007,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VL4RE8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vl4re8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VL8RE8_V --------------------------------------------------------------------
-static InstructionDefinition vl8re8_v_vd_rs1 (
-	ISA32_RV32IMACFDV,
-	"vl8re8_v",
-	(uint32_t) 0xe2800007,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VL8RE8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vl8re8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VL1RE16_V -------------------------------------------------------------------
-static InstructionDefinition vl1re16_v_vd_rs1 (
-	ISA32_RV32IMACFDV,
-	"vl1re16_v",
-	(uint32_t) 0x2805007,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VL1RE16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vl1re16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VL2RE16_V -------------------------------------------------------------------
-static InstructionDefinition vl2re16_v_vd_rs1 (
-	ISA32_RV32IMACFDV,
-	"vl2re16_v",
-	(uint32_t) 0x22805007,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VL2RE16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vl2re16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VL4RE16_V -------------------------------------------------------------------
-static InstructionDefinition vl4re16_v_vd_rs1 (
-	ISA32_RV32IMACFDV,
-	"vl4re16_v",
-	(uint32_t) 0x62805007,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VL4RE16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vl4re16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VL8RE16_V -------------------------------------------------------------------
-static InstructionDefinition vl8re16_v_vd_rs1 (
-	ISA32_RV32IMACFDV,
-	"vl8re16_v",
-	(uint32_t) 0xe2805007,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VL8RE16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vl8re16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VL1RE32_V -------------------------------------------------------------------
-static InstructionDefinition vl1re32_v_vd_rs1 (
-	ISA32_RV32IMACFDV,
-	"vl1re32_v",
-	(uint32_t) 0x2806007,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VL1RE32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vl1re32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VL2RE32_V -------------------------------------------------------------------
-static InstructionDefinition vl2re32_v_vd_rs1 (
-	ISA32_RV32IMACFDV,
-	"vl2re32_v",
-	(uint32_t) 0x22806007,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VL2RE32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vl2re32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VL4RE32_V -------------------------------------------------------------------
-static InstructionDefinition vl4re32_v_vd_rs1 (
-	ISA32_RV32IMACFDV,
-	"vl4re32_v",
-	(uint32_t) 0x62806007,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VL4RE32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vl4re32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VL8RE32_V -------------------------------------------------------------------
-static InstructionDefinition vl8re32_v_vd_rs1 (
-	ISA32_RV32IMACFDV,
-	"vl8re32_v",
-	(uint32_t) 0xe2806007,
-	(uint32_t) 0xfff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VL8RE32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vl8re32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + "]");
 // -----------------------------------------------------------------------------
 		return ss.str();
 	}
@@ -10169,12 +1508,44 @@ cp.code() += "} // block\n";
 { // block
 cp.code() += "{ // block\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_mask(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, " + std::to_string(vm) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
 cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
 // -----------------------------------------------------------------------------
 		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLM_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
 	}
 
 		return true;
@@ -10203,12 +1574,12 @@ ss << "vlm_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std:
 	}
 );
 
-// VLR_V -----------------------------------------------------------------------
-static InstructionDefinition vlr_v_vd_rs1_nf (
+// VLOXEI8_V -------------------------------------------------------------------
+static InstructionDefinition vloxei8_v_vd_rs1_vs2_vm (
 	ISA32_RV32IMACFDV,
-	"vlr_v",
-	(uint32_t) 0x2800007,
-	(uint32_t) 0x1ff0707f,
+	"vloxei8_v",
+	(uint32_t) 0xc000007,
+	(uint32_t) 0xfc00707f,
 	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
 	{
 
@@ -10223,16 +1594,19 @@ vd += R_vd_0.read(ba) << 0;
 etiss_uint8 rs1 = 0;
 static BitArrayRange R_rs1_0(19, 15);
 rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
 
 // -----------------------------------------------------------------------------
 
 	{
 		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
 
-		cp.code() = std::string("//VLR_V\n");
+		cp.code() = std::string("//VLOXEI8_V\n");
 
 // -----------------------------------------------------------------------------
 { // block
@@ -10242,13 +1616,47 @@ cp.code() += "} // block\n";
 } // block
 { // block
 cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_encoded_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
 cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
 // -----------------------------------------------------------------------------
 		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLOXEI8_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
 	}
 
 		return true;
@@ -10263,26 +1671,29 @@ vd += R_vd_0.read(ba) << 0;
 etiss_uint8 rs1 = 0;
 static BitArrayRange R_rs1_0(19, 15);
 rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
 
 // -----------------------------------------------------------------------------
 
 		std::stringstream ss;
 // -----------------------------------------------------------------------------
-ss << "vlr_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | nf=" + std::to_string(nf) + "]");
+ss << "vloxei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
 // -----------------------------------------------------------------------------
 		return ss.str();
 	}
 );
 
-// VLSSEGE8_V ------------------------------------------------------------------
-static InstructionDefinition vlssege8_v_vd_rs1_rs2_vm_nf (
+// VLOXEI16_V ------------------------------------------------------------------
+static InstructionDefinition vloxei16_v_vd_rs1_vs2_vm (
 	ISA32_RV32IMACFDV,
-	"vlssege8_v",
-	(uint32_t) 0x8000007,
-	(uint32_t) 0x1c00707f,
+	"vloxei16_v",
+	(uint32_t) 0xc005007,
+	(uint32_t) 0xfc00707f,
 	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
 	{
 
@@ -10297,22 +1708,19 @@ vd += R_vd_0.read(ba) << 0;
 etiss_uint8 rs1 = 0;
 static BitArrayRange R_rs1_0(19, 15);
 rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 rs2 = 0;
-static BitArrayRange R_rs2_0(24, 20);
-rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
 etiss_uint8 vm = 0;
 static BitArrayRange R_vm_0(25, 25);
 vm += R_vm_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
 
 // -----------------------------------------------------------------------------
 
 	{
 		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
 
-		cp.code() = std::string("//VLSSEGE8_V\n");
+		cp.code() = std::string("//VLOXEI16_V\n");
 
 // -----------------------------------------------------------------------------
 { // block
@@ -10322,13 +1730,47 @@ cp.code() += "} // block\n";
 } // block
 { // block
 cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_encoded_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
 cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
 // -----------------------------------------------------------------------------
 		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLOXEI16_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
 	}
 
 		return true;
@@ -10343,32 +1785,29 @@ vd += R_vd_0.read(ba) << 0;
 etiss_uint8 rs1 = 0;
 static BitArrayRange R_rs1_0(19, 15);
 rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 rs2 = 0;
-static BitArrayRange R_rs2_0(24, 20);
-rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
 etiss_uint8 vm = 0;
 static BitArrayRange R_vm_0(25, 25);
 vm += R_vm_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
 
 // -----------------------------------------------------------------------------
 
 		std::stringstream ss;
 // -----------------------------------------------------------------------------
-ss << "vlssege8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+ss << "vloxei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
 // -----------------------------------------------------------------------------
 		return ss.str();
 	}
 );
 
-// VLSSEGE16_V -----------------------------------------------------------------
-static InstructionDefinition vlssege16_v_vd_rs1_rs2_vm_nf (
+// VLOXEI32_V ------------------------------------------------------------------
+static InstructionDefinition vloxei32_v_vd_rs1_vs2_vm (
 	ISA32_RV32IMACFDV,
-	"vlssege16_v",
-	(uint32_t) 0x8005007,
-	(uint32_t) 0x1c00707f,
+	"vloxei32_v",
+	(uint32_t) 0xc006007,
+	(uint32_t) 0xfc00707f,
 	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
 	{
 
@@ -10383,22 +1822,19 @@ vd += R_vd_0.read(ba) << 0;
 etiss_uint8 rs1 = 0;
 static BitArrayRange R_rs1_0(19, 15);
 rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 rs2 = 0;
-static BitArrayRange R_rs2_0(24, 20);
-rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
 etiss_uint8 vm = 0;
 static BitArrayRange R_vm_0(25, 25);
 vm += R_vm_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
 
 // -----------------------------------------------------------------------------
 
 	{
 		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
 
-		cp.code() = std::string("//VLSSEGE16_V\n");
+		cp.code() = std::string("//VLOXEI32_V\n");
 
 // -----------------------------------------------------------------------------
 { // block
@@ -10408,13 +1844,47 @@ cp.code() += "} // block\n";
 } // block
 { // block
 cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_encoded_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
 cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
 // -----------------------------------------------------------------------------
 		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLOXEI32_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
 	}
 
 		return true;
@@ -10429,32 +1899,29 @@ vd += R_vd_0.read(ba) << 0;
 etiss_uint8 rs1 = 0;
 static BitArrayRange R_rs1_0(19, 15);
 rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 rs2 = 0;
-static BitArrayRange R_rs2_0(24, 20);
-rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
 etiss_uint8 vm = 0;
 static BitArrayRange R_vm_0(25, 25);
 vm += R_vm_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
 
 // -----------------------------------------------------------------------------
 
 		std::stringstream ss;
 // -----------------------------------------------------------------------------
-ss << "vlssege16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+ss << "vloxei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
 // -----------------------------------------------------------------------------
 		return ss.str();
 	}
 );
 
-// VLSSEGE32_V -----------------------------------------------------------------
-static InstructionDefinition vlssege32_v_vd_rs1_rs2_vm_nf (
+// VLUXEI8_V -------------------------------------------------------------------
+static InstructionDefinition vluxei8_v_vd_rs1_vs2_vm (
 	ISA32_RV32IMACFDV,
-	"vlssege32_v",
-	(uint32_t) 0x8006007,
-	(uint32_t) 0x1c00707f,
+	"vluxei8_v",
+	(uint32_t) 0x4000007,
+	(uint32_t) 0xfc00707f,
 	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
 	{
 
@@ -10469,22 +1936,19 @@ vd += R_vd_0.read(ba) << 0;
 etiss_uint8 rs1 = 0;
 static BitArrayRange R_rs1_0(19, 15);
 rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 rs2 = 0;
-static BitArrayRange R_rs2_0(24, 20);
-rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
 etiss_uint8 vm = 0;
 static BitArrayRange R_vm_0(25, 25);
 vm += R_vm_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
 
 // -----------------------------------------------------------------------------
 
 	{
 		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
 
-		cp.code() = std::string("//VLSSEGE32_V\n");
+		cp.code() = std::string("//VLUXEI8_V\n");
 
 // -----------------------------------------------------------------------------
 { // block
@@ -10494,13 +1958,47 @@ cp.code() += "} // block\n";
 } // block
 { // block
 cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_encoded_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
 cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
 // -----------------------------------------------------------------------------
 		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLUXEI8_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
 	}
 
 		return true;
@@ -10515,21 +2013,930 @@ vd += R_vd_0.read(ba) << 0;
 etiss_uint8 rs1 = 0;
 static BitArrayRange R_rs1_0(19, 15);
 rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 rs2 = 0;
-static BitArrayRange R_rs2_0(24, 20);
-rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
 etiss_uint8 vm = 0;
 static BitArrayRange R_vm_0(25, 25);
 vm += R_vm_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
 
 // -----------------------------------------------------------------------------
 
 		std::stringstream ss;
 // -----------------------------------------------------------------------------
-ss << "vlssege32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+ss << "vluxei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLUXEI16_V ------------------------------------------------------------------
+static InstructionDefinition vluxei16_v_vd_rs1_vs2_vm (
+	ISA32_RV32IMACFDV,
+	"vluxei16_v",
+	(uint32_t) 0x4005007,
+	(uint32_t) 0xfc00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLUXEI16_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_encoded_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLUXEI16_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vluxei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLUXEI32_V ------------------------------------------------------------------
+static InstructionDefinition vluxei32_v_vd_rs1_vs2_vm (
+	ISA32_RV32IMACFDV,
+	"vluxei32_v",
+	(uint32_t) 0x4006007,
+	(uint32_t) 0xfc00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLUXEI32_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_encoded_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLUXEI32_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vluxei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSOXEI8_V -------------------------------------------------------------------
+static InstructionDefinition vsoxei8_v_vs3_rs1_vs2_vm (
+	ISA32_RV32IMACFDV,
+	"vsoxei8_v",
+	(uint32_t) 0xc000027,
+	(uint32_t) 0xfc00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSOXEI8_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_encoded_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSOXEI8_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsoxei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSOXEI16_V ------------------------------------------------------------------
+static InstructionDefinition vsoxei16_v_vs3_rs1_vs2_vm (
+	ISA32_RV32IMACFDV,
+	"vsoxei16_v",
+	(uint32_t) 0xc005027,
+	(uint32_t) 0xfc00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSOXEI16_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_encoded_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSOXEI16_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsoxei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSOXEI32_V ------------------------------------------------------------------
+static InstructionDefinition vsoxei32_v_vs3_rs1_vs2_vm (
+	ISA32_RV32IMACFDV,
+	"vsoxei32_v",
+	(uint32_t) 0xc006027,
+	(uint32_t) 0xfc00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSOXEI32_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_encoded_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSOXEI32_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsoxei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSUXEI8_V -------------------------------------------------------------------
+static InstructionDefinition vsuxei8_v_vs3_rs1_vs2_vm (
+	ISA32_RV32IMACFDV,
+	"vsuxei8_v",
+	(uint32_t) 0x4000027,
+	(uint32_t) 0xfc00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSUXEI8_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_encoded_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSUXEI8_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsuxei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSUXEI16_V ------------------------------------------------------------------
+static InstructionDefinition vsuxei16_v_vs3_rs1_vs2_vm (
+	ISA32_RV32IMACFDV,
+	"vsuxei16_v",
+	(uint32_t) 0x4005027,
+	(uint32_t) 0xfc00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSUXEI16_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_encoded_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSUXEI16_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsuxei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSUXEI32_V ------------------------------------------------------------------
+static InstructionDefinition vsuxei32_v_vs3_rs1_vs2_vm (
+	ISA32_RV32IMACFDV,
+	"vsuxei32_v",
+	(uint32_t) 0x4006027,
+	(uint32_t) 0xfc00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSUXEI32_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_encoded_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSUXEI32_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsuxei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + "]");
 // -----------------------------------------------------------------------------
 		return ss.str();
 	}
@@ -10577,13 +2984,47 @@ cp.code() += "} // block\n";
 } // block
 { // block
 cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
 cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
 // -----------------------------------------------------------------------------
 		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLSEGE8_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
 	}
 
 		return true;
@@ -10657,13 +3098,47 @@ cp.code() += "} // block\n";
 } // block
 { // block
 cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
 cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
 // -----------------------------------------------------------------------------
 		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLSEGE16_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
 	}
 
 		return true;
@@ -10737,13 +3212,47 @@ cp.code() += "} // block\n";
 } // block
 { // block
 cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
 cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
 // -----------------------------------------------------------------------------
 		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLSEGE32_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
 	}
 
 		return true;
@@ -11117,6 +3626,366 @@ ss << "vssege32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1="
 	}
 );
 
+// VLSSEGE8_V ------------------------------------------------------------------
+static InstructionDefinition vlssege8_v_vd_rs1_rs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vlssege8_v",
+	(uint32_t) 0x8000007,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 rs2 = 0;
+static BitArrayRange R_rs2_0(24, 20);
+rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLSSEGE8_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_stride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), (etiss_uint16)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs2) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLSSEGE8_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 rs2 = 0;
+static BitArrayRange R_rs2_0(24, 20);
+rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vlssege8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLSSEGE16_V -----------------------------------------------------------------
+static InstructionDefinition vlssege16_v_vd_rs1_rs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vlssege16_v",
+	(uint32_t) 0x8005007,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 rs2 = 0;
+static BitArrayRange R_rs2_0(24, 20);
+rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLSSEGE16_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_stride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), (etiss_uint16)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs2) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLSSEGE16_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 rs2 = 0;
+static BitArrayRange R_rs2_0(24, 20);
+rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vlssege16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLSSEGE32_V -----------------------------------------------------------------
+static InstructionDefinition vlssege32_v_vd_rs1_rs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vlssege32_v",
+	(uint32_t) 0x8006007,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 rs2 = 0;
+static BitArrayRange R_rs2_0(24, 20);
+rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLSSEGE32_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_stride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), (etiss_uint16)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs2) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLSSEGE32_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 rs2 = 0;
+static BitArrayRange R_rs2_0(24, 20);
+rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vlssege32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
 // VSSSEGE8_V ------------------------------------------------------------------
 static InstructionDefinition vsssege8_v_vs3_rs1_rs2_vm_nf (
 	ISA32_RV32IMACFDV,
@@ -11472,6 +4341,1677 @@ nf += R_nf_0.read(ba) << 0;
 		std::stringstream ss;
 // -----------------------------------------------------------------------------
 ss << "vsssege32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLUXSEGEI8_V ----------------------------------------------------------------
+static InstructionDefinition vluxsegei8_v_vd_rs1_vs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vluxsegei8_v",
+	(uint32_t) 0x4000007,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLUXSEGEI8_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLUXSEGEI8_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vluxsegei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLUXSEGEI16_V ---------------------------------------------------------------
+static InstructionDefinition vluxsegei16_v_vd_rs1_vs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vluxsegei16_v",
+	(uint32_t) 0x4005007,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLUXSEGEI16_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLUXSEGEI16_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vluxsegei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLUXSEGEI32_V ---------------------------------------------------------------
+static InstructionDefinition vluxsegei32_v_vd_rs1_vs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vluxsegei32_v",
+	(uint32_t) 0x4006007,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLUXSEGEI32_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLUXSEGEI32_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vluxsegei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLOXSEGEI8_V ----------------------------------------------------------------
+static InstructionDefinition vloxsegei8_v_vd_rs1_vs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vloxsegei8_v",
+	(uint32_t) 0xc000007,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLOXSEGEI8_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLOXSEGEI8_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vloxsegei8_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLOXSEGEI16_V ---------------------------------------------------------------
+static InstructionDefinition vloxsegei16_v_vd_rs1_vs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vloxsegei16_v",
+	(uint32_t) 0xc005007,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLOXSEGEI16_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLOXSEGEI16_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vloxsegei16_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLOXSEGEI32_V ---------------------------------------------------------------
+static InstructionDefinition vloxsegei32_v_vd_rs1_vs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vloxsegei32_v",
+	(uint32_t) 0xc006007,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLOXSEGEI32_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLOXSEGEI32_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vloxsegei32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSUXSEGEI8_V ----------------------------------------------------------------
+static InstructionDefinition vsuxsegei8_v_vs3_rs1_vs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vsuxsegei8_v",
+	(uint32_t) 0x4000027,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSUXSEGEI8_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSUXSEGEI8_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsuxsegei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSUXSEGEI16_V ---------------------------------------------------------------
+static InstructionDefinition vsuxsegei16_v_vs3_rs1_vs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vsuxsegei16_v",
+	(uint32_t) 0x4005027,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSUXSEGEI16_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSUXSEGEI16_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsuxsegei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSUXSEGEI32_V ---------------------------------------------------------------
+static InstructionDefinition vsuxsegei32_v_vs3_rs1_vs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vsuxsegei32_v",
+	(uint32_t) 0x4006027,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSUXSEGEI32_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSUXSEGEI32_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsuxsegei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSOXSEGEI8_V ----------------------------------------------------------------
+static InstructionDefinition vsoxsegei8_v_vs3_rs1_vs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vsoxsegei8_v",
+	(uint32_t) 0xc000027,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSOXSEGEI8_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSOXSEGEI8_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsoxsegei8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSOXSEGEI16_V ---------------------------------------------------------------
+static InstructionDefinition vsoxsegei16_v_vs3_rs1_vs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vsoxsegei16_v",
+	(uint32_t) 0xc005027,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSOXSEGEI16_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSOXSEGEI16_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsoxsegei16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSOXSEGEI32_V ---------------------------------------------------------------
+static InstructionDefinition vsoxsegei32_v_vs3_rs1_vs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vsoxsegei32_v",
+	(uint32_t) 0xc006027,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSOXSEGEI32_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_index(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), " + std::to_string(vs2) + "ULL);\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSOXSEGEI32_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vs2 = 0;
+static BitArrayRange R_vs2_0(24, 20);
+vs2 += R_vs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsoxsegei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vs2=" + std::to_string(vs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLR_V -----------------------------------------------------------------------
+static InstructionDefinition vlr_v_vd_width_rs1_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vlr_v",
+	(uint32_t) 0x800007,
+	(uint32_t) 0x1df0007f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 width = 0;
+static BitArrayRange R_width_0(14, 12);
+width += R_width_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLR_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, " + std::to_string(width) + "ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_registers(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLR_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 width = 0;
+static BitArrayRange R_width_0(14, 12);
+width += R_width_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vlr_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | width=" + std::to_string(width) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSR_V -----------------------------------------------------------------------
+static InstructionDefinition vsr_v_vs3_rs1_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vsr_v",
+	(uint32_t) 0x800027,
+	(uint32_t) 0x1df0707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSR_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_registers(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSR_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsr_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
 // -----------------------------------------------------------------------------
 		return ss.str();
 	}
@@ -12183,12 +6723,44 @@ cp.code() += "} // block\n";
 { // block
 cp.code() += "{ // block\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_mask(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, " + std::to_string(vm) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
 cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
 // -----------------------------------------------------------------------------
 		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSM_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
 	}
 
 		return true;
@@ -12212,80 +6784,6 @@ vm += R_vm_0.read(ba) << 0;
 		std::stringstream ss;
 // -----------------------------------------------------------------------------
 ss << "vsm_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSR_V -----------------------------------------------------------------------
-static InstructionDefinition vsr_v_vs3_rs1_nf (
-	ISA32_RV32IMACFDV,
-	"vsr_v",
-	(uint32_t) 0x2800027,
-	(uint32_t) 0x1ff0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSR_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsr_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | nf=" + std::to_string(nf) + "]");
 // -----------------------------------------------------------------------------
 		return ss.str();
 	}

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32xInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32xInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the RVZve32x
  * instruction set for the RV32IMACFDV core architecture.
@@ -1259,228 +1259,6 @@ vm += R_vm_0.read(ba) << 0;
 		std::stringstream ss;
 // -----------------------------------------------------------------------------
 ss << "vlse32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLE8FF_V --------------------------------------------------------------------
-static InstructionDefinition vle8ff_v_vd_rs1_vm (
-	ISA32_RV32IMACFDV,
-	"vle8ff_v",
-	(uint32_t) 0x1000007,
-	(uint32_t) 0xfdf0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLE8FF_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vle8ff_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLE16FF_V -------------------------------------------------------------------
-static InstructionDefinition vle16ff_v_vd_rs1_vm (
-	ISA32_RV32IMACFDV,
-	"vle16ff_v",
-	(uint32_t) 0x1005007,
-	(uint32_t) 0xfdf0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLE16FF_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vle16ff_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VLE32FF_V -------------------------------------------------------------------
-static InstructionDefinition vle32ff_v_vd_rs1_vm (
-	ISA32_RV32IMACFDV,
-	"vle32ff_v",
-	(uint32_t) 0x1006007,
-	(uint32_t) 0xfdf0707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VLE32FF_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vd = 0;
-static BitArrayRange R_vd_0(11, 7);
-vd += R_vd_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vle32ff_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + "]");
 // -----------------------------------------------------------------------------
 		return ss.str();
 	}
@@ -2960,6 +2738,330 @@ ss << "vsuxei32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1="
 	}
 );
 
+// VLE8FF_V --------------------------------------------------------------------
+static InstructionDefinition vle8ff_v_vd_rs1_vm (
+	ISA32_RV32IMACFDV,
+	"vle8ff_v",
+	(uint32_t) 0x1000007,
+	(uint32_t) 0xfdf0707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLE8FF_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_encoded_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLE8FF_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vle8ff_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLE16FF_V -------------------------------------------------------------------
+static InstructionDefinition vle16ff_v_vd_rs1_vm (
+	ISA32_RV32IMACFDV,
+	"vle16ff_v",
+	(uint32_t) 0x1005007,
+	(uint32_t) 0xfdf0707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLE16FF_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_encoded_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLE16FF_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vle16ff_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLE32FF_V -------------------------------------------------------------------
+static InstructionDefinition vle32ff_v_vd_rs1_vm (
+	ISA32_RV32IMACFDV,
+	"vle32ff_v",
+	(uint32_t) 0x1006007,
+	(uint32_t) 0xfdf0707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLE32FF_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_encoded_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLE32FF_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vle32ff_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
 // VLSEGE8_V -------------------------------------------------------------------
 static InstructionDefinition vlsege8_v_vd_rs1_vm_nf (
 	ISA32_RV32IMACFDV,
@@ -3639,6 +3741,348 @@ nf += R_nf_0.read(ba) << 0;
 		std::stringstream ss;
 // -----------------------------------------------------------------------------
 ss << "vssege32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLSEGE8FF_V -----------------------------------------------------------------
+static InstructionDefinition vlsege8ff_v_vd_rs1_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vlsege8ff_v",
+	(uint32_t) 0x1000007,
+	(uint32_t) 0x1df0707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLSEGE8FF_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLSEGE8FF_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vlsege8ff_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLSEGE16FF_V ----------------------------------------------------------------
+static InstructionDefinition vlsege16ff_v_vd_rs1_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vlsege16ff_v",
+	(uint32_t) 0x1005007,
+	(uint32_t) 0x1df0707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLSEGE16FF_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLSEGE16FF_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vlsege16ff_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VLSEGE32FF_V ----------------------------------------------------------------
+static InstructionDefinition vlsege32ff_v_vd_rs1_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vlsege32ff_v",
+	(uint32_t) 0x1006007,
+	(uint32_t) 0x1df0707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VLSEGE32FF_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vload_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vd) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VLSEGE32FF_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vd = 0;
+static BitArrayRange R_vd_0(11, 7);
+vd += R_vd_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vlsege32ff_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
 // -----------------------------------------------------------------------------
 		return ss.str();
 	}

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32xInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32xInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the RVZve32x
  * instruction set for the RV32IMACFDV core architecture.
@@ -10775,264 +10775,6 @@ ss << "vlsege32_v" << " # " << ba << (" [vd=" + std::to_string(vd) + " | rs1=" +
 	}
 );
 
-// VSSSEGE8_V ------------------------------------------------------------------
-static InstructionDefinition vsssege8_v_vs3_rs1_rs2_vm_nf (
-	ISA32_RV32IMACFDV,
-	"vsssege8_v",
-	(uint32_t) 0x000027,
-	(uint32_t) 0x1c00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 rs2 = 0;
-static BitArrayRange R_rs2_0(24, 20);
-rs2 += R_rs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSSSEGE8_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 rs2 = 0;
-static BitArrayRange R_rs2_0(24, 20);
-rs2 += R_rs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsssege8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSSSEGE16_V -----------------------------------------------------------------
-static InstructionDefinition vsssege16_v_vs3_rs1_rs2_vm_nf (
-	ISA32_RV32IMACFDV,
-	"vsssege16_v",
-	(uint32_t) 0x005027,
-	(uint32_t) 0x1c00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 rs2 = 0;
-static BitArrayRange R_rs2_0(24, 20);
-rs2 += R_rs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSSSEGE16_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 rs2 = 0;
-static BitArrayRange R_rs2_0(24, 20);
-rs2 += R_rs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsssege16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
-// VSSSEGE32_V -----------------------------------------------------------------
-static InstructionDefinition vsssege32_v_vs3_rs1_rs2_vm_nf (
-	ISA32_RV32IMACFDV,
-	"vsssege32_v",
-	(uint32_t) 0x006027,
-	(uint32_t) 0x1c00707f,
-	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
-	{
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 rs2 = 0;
-static BitArrayRange R_rs2_0(24, 20);
-rs2 += R_rs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-	{
-		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
-
-		cp.code() = std::string("//VSSSEGE32_V\n");
-
-// -----------------------------------------------------------------------------
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
-cp.code() += "} // block\n";
-} // block
-{ // block
-cp.code() += "{ // block\n";
-cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
-cp.code() += "} // block\n";
-} // block
-cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
-cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
-// -----------------------------------------------------------------------------
-		cp.getAffectedRegisters().add("instructionPointer", 32);
-	}
-
-		return true;
-	},
-	0,
-	[] (BitArray & ba, Instruction & instr)
-	{
-// -----------------------------------------------------------------------------
-etiss_uint8 vs3 = 0;
-static BitArrayRange R_vs3_0(11, 7);
-vs3 += R_vs3_0.read(ba) << 0;
-etiss_uint8 rs1 = 0;
-static BitArrayRange R_rs1_0(19, 15);
-rs1 += R_rs1_0.read(ba) << 0;
-etiss_uint8 rs2 = 0;
-static BitArrayRange R_rs2_0(24, 20);
-rs2 += R_rs2_0.read(ba) << 0;
-etiss_uint8 vm = 0;
-static BitArrayRange R_vm_0(25, 25);
-vm += R_vm_0.read(ba) << 0;
-etiss_uint8 nf = 0;
-static BitArrayRange R_nf_0(31, 29);
-nf += R_nf_0.read(ba) << 0;
-
-// -----------------------------------------------------------------------------
-
-		std::stringstream ss;
-// -----------------------------------------------------------------------------
-ss << "vsssege32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
-// -----------------------------------------------------------------------------
-		return ss.str();
-	}
-);
-
 // VSSEGE8_V -------------------------------------------------------------------
 static InstructionDefinition vssege8_v_vs3_rs1_vm_nf (
 	ISA32_RV32IMACFDV,
@@ -11080,7 +10822,7 @@ cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
 cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
 cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
-cp.code() += "etiss_uint32 ret = etiss_vstore_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string((nf & 7ULL) + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
 cp.code() += "if (ret != 0LL) { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
@@ -11194,7 +10936,7 @@ cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
 cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
 cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
-cp.code() += "etiss_uint32 ret = etiss_vstore_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string((nf & 7ULL) + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
 cp.code() += "if (ret != 0LL) { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
@@ -11308,7 +11050,7 @@ cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
 cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
 cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
-cp.code() += "etiss_uint32 ret = etiss_vstore_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string((nf & 7ULL) + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
 cp.code() += "if (ret != 0LL) { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
@@ -11370,6 +11112,366 @@ nf += R_nf_0.read(ba) << 0;
 		std::stringstream ss;
 // -----------------------------------------------------------------------------
 ss << "vssege32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSSSEGE8_V ------------------------------------------------------------------
+static InstructionDefinition vsssege8_v_vs3_rs1_rs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vsssege8_v",
+	(uint32_t) 0x8000027,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 rs2 = 0;
+static BitArrayRange R_rs2_0(24, 20);
+rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSSSEGE8_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_stride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), (etiss_uint16)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs2) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSSSEGE8_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 rs2 = 0;
+static BitArrayRange R_rs2_0(24, 20);
+rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsssege8_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSSSEGE16_V -----------------------------------------------------------------
+static InstructionDefinition vsssege16_v_vs3_rs1_rs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vsssege16_v",
+	(uint32_t) 0x8005027,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 rs2 = 0;
+static BitArrayRange R_rs2_0(24, 20);
+rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSSSEGE16_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_stride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), (etiss_uint16)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs2) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSSSEGE16_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 rs2 = 0;
+static BitArrayRange R_rs2_0(24, 20);
+rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsssege16_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
+// -----------------------------------------------------------------------------
+		return ss.str();
+	}
+);
+
+// VSSSEGE32_V -----------------------------------------------------------------
+static InstructionDefinition vsssege32_v_vs3_rs1_rs2_vm_nf (
+	ISA32_RV32IMACFDV,
+	"vsssege32_v",
+	(uint32_t) 0x8006027,
+	(uint32_t) 0x1c00707f,
+	[] (BitArray & ba,etiss::CodeSet & cs,InstructionContext & ic)
+	{
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 rs2 = 0;
+static BitArrayRange R_rs2_0(24, 20);
+rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+	{
+		CodePart & cp = cs.append(CodePart::INITIALREQUIRED);
+
+		cp.code() = std::string("//VSSSEGE32_V\n");
+
+// -----------------------------------------------------------------------------
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "cpu->nextPc = " + std::to_string(ic.current_address_ + 4) + "ULL;\n";
+cp.code() += "} // block\n";
+} // block
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
+cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_stride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string(nf + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]), (etiss_uint16)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs2) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
+cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
+// -----------------------------------------------------------------------------
+		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSSSEGE32_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
+	}
+
+		return true;
+	},
+	0,
+	[] (BitArray & ba, Instruction & instr)
+	{
+// -----------------------------------------------------------------------------
+etiss_uint8 vs3 = 0;
+static BitArrayRange R_vs3_0(11, 7);
+vs3 += R_vs3_0.read(ba) << 0;
+etiss_uint8 rs1 = 0;
+static BitArrayRange R_rs1_0(19, 15);
+rs1 += R_rs1_0.read(ba) << 0;
+etiss_uint8 rs2 = 0;
+static BitArrayRange R_rs2_0(24, 20);
+rs2 += R_rs2_0.read(ba) << 0;
+etiss_uint8 vm = 0;
+static BitArrayRange R_vm_0(25, 25);
+vm += R_vm_0.read(ba) << 0;
+etiss_uint8 nf = 0;
+static BitArrayRange R_nf_0(31, 29);
+nf += R_nf_0.read(ba) << 0;
+
+// -----------------------------------------------------------------------------
+
+		std::stringstream ss;
+// -----------------------------------------------------------------------------
+ss << "vsssege32_v" << " # " << ba << (" [vs3=" + std::to_string(vs3) + " | rs1=" + std::to_string(rs1) + " | rs2=" + std::to_string(rs2) + " | vm=" + std::to_string(vm) + " | nf=" + std::to_string(nf) + "]");
 // -----------------------------------------------------------------------------
 		return ss.str();
 	}

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32xInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32xInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the RVZve32x
  * instruction set for the RV32IMACFDV core architecture.
@@ -11075,13 +11075,47 @@ cp.code() += "} // block\n";
 } // block
 { // block
 cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 0LL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string((nf & 7ULL) + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
 cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
 // -----------------------------------------------------------------------------
 		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSSEGE8_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
 	}
 
 		return true;
@@ -11155,13 +11189,47 @@ cp.code() += "} // block\n";
 } // block
 { // block
 cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 5ULL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string((nf & 7ULL) + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
 cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
 // -----------------------------------------------------------------------------
 		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSSEGE16_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
 	}
 
 		return true;
@@ -11235,13 +11303,47 @@ cp.code() += "} // block\n";
 } // block
 { // block
 cp.code() += "{ // block\n";
+cp.code() += "etiss_uint32 _vtype = *((RV32IMACFDV*)cpu)->CSR[3105ULL];\n";
+cp.code() += "etiss_uint32 _eew = vcfg_concatEEW(0LL, 6ULL);\n";
 cp.code() += "etiss_uint32 _vstart = *((RV32IMACFDV*)cpu)->CSR[8ULL];\n";
+cp.code() += "etiss_uint32 _vl = *((RV32IMACFDV*)cpu)->CSR[3104ULL];\n";
+cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "etiss_uint32 ret = etiss_vstore_segment_unitstride(cpu, system, plugin_pointers, ((RV32IMACFDV*)cpu)->V, _vtype, " + std::to_string(vm) + "ULL, _eew, " + std::to_string((nf & 7ULL) + 1ULL) + "ULL, " + std::to_string(vs3) + "ULL, _vstart, _vlen, _vl, (etiss_uint64)(*((RV32IMACFDV*)cpu)->X[" + std::to_string(rs1) + "ULL]));\n";
+cp.code() += "if (ret != 0LL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = ret >> 8ULL;\n";
+{ // procedure
+cp.code() += "{ // procedure\n";
+cp.code() += "RV32IMACFDV_raise(cpu, system, plugin_pointers, 0LL, 2ULL);\n";
+cp.code() += "goto instr_exit_" + std::to_string(ic.current_address_) + ";\n";
+cp.code() += "} // procedure\n";
+} // procedure
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
+cp.code() += "else { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[8ULL] = 0LL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\n";
 cp.code() += "cpu->instructionPointer = cpu->nextPc;\n";
 // -----------------------------------------------------------------------------
 		cp.getAffectedRegisters().add("instructionPointer", 32);
+	}
+	{
+		CodePart & cp = cs.append(CodePart::APPENDEDRETURNINGREQUIRED);
+
+		cp.code() = std::string("//VSSEGE32_V\n");
+
+// -----------------------------------------------------------------------------
+cp.code() += "if (cpu->return_pending || cpu->exception) return cpu->exception;\n";
+// -----------------------------------------------------------------------------
 	}
 
 		return true;

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32xInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve32xInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the RVZve32x
  * instruction set for the RV32IMACFDV core architecture.
@@ -55,13 +55,19 @@ cp.code() += "etiss_uint8 sew = (vtype_extractSEW(" + std::to_string(zimm) + "UL
 cp.code() += "etiss_uint8 lmul = (vtype_extractLMUL(" + std::to_string(zimm) + "ULL)) & 0x7;\n";
 cp.code() += "etiss_uint8 vta = (vtype_extractTA(" + std::to_string(zimm) + "ULL)) & 0x1;\n";
 cp.code() += "etiss_uint8 vma = (vtype_extractMA(" + std::to_string(zimm) + "ULL)) & 0x1;\n";
+cp.code() += "etiss_uint32 vtype_result = " + std::to_string(zimm) + "ULL;\n";
 cp.code() += "etiss_uint32 _vlmax = 0LL;\n";
-cp.code() += "etiss_uint32 _illmask = 0LL;\n";
 cp.code() += "etiss_uint32 vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "if (sew == 3ULL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "vtype_result = 2147483648ULL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "if (lmul & 4ULL) { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
-cp.code() += "_illmask = 2147483648ULL;\n";
 cp.code() += "if (lmul == 6ULL) { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
@@ -79,7 +85,11 @@ cp.code() += "} // conditional\n";
 cp.code() += "else { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
-cp.code() += "_vlmax = vlen / (8ULL << sew) / 8ULL;\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "vtype_result = 2147483648ULL;\n";
+cp.code() += "} // block\n";
+} // block
 cp.code() += "} // block\n";
 } // block
 cp.code() += "} // conditional\n";
@@ -89,7 +99,6 @@ cp.code() += "} // conditional\n";
 cp.code() += "else { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
-cp.code() += "_illmask = 0LL;\n";
 cp.code() += "if (lmul == 0LL) { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
@@ -166,7 +175,7 @@ cp.code() += "} // block\n";
 } // block
 cp.code() += "} // conditional\n";
 cp.code() += "*((RV32IMACFDV*)cpu)->CSR[3104ULL] = _vl;\n";
-cp.code() += "*((RV32IMACFDV*)cpu)->CSR[3105ULL] = _illmask | " + std::to_string(zimm) + "ULL;\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[3105ULL] = vtype_result;\n";
 if (rd != 0LL) { // conditional
 cp.code() += "*((RV32IMACFDV*)cpu)->X[" + std::to_string(rd) + "ULL] = _vl;\n";
 } // conditional
@@ -249,12 +258,12 @@ cp.code() += "etiss_uint8 lmul = (vtype_extractLMUL(" + std::to_string(vtypei) +
 cp.code() += "etiss_uint8 vta = (vtype_extractTA(" + std::to_string(vtypei) + "ULL)) & 0x1;\n";
 cp.code() += "etiss_uint8 vma = (vtype_extractMA(" + std::to_string(vtypei) + "ULL)) & 0x1;\n";
 cp.code() += "etiss_uint32 _vlmax = 0LL;\n";
-cp.code() += "etiss_uint32 _vtype_result = " + std::to_string(vtypei) + "ULL;\n";
+cp.code() += "etiss_uint32 vtype_result = " + std::to_string(vtypei) + "ULL;\n";
 cp.code() += "etiss_uint32 vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
 cp.code() += "if (sew == 3ULL) { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
-cp.code() += "_vtype_result = 2147483648ULL;\n";
+cp.code() += "vtype_result = 2147483648ULL;\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "} // conditional\n";
@@ -280,7 +289,7 @@ cp.code() += "else { // conditional\n";
 cp.code() += "{ // block\n";
 { // block
 cp.code() += "{ // block\n";
-cp.code() += "_vtype_result = 2147483648ULL;\n";
+cp.code() += "vtype_result = 2147483648ULL;\n";
 cp.code() += "} // block\n";
 } // block
 cp.code() += "} // block\n";
@@ -347,7 +356,7 @@ cp.code() += "} // block\n";
 } // block
 cp.code() += "} // conditional\n";
 cp.code() += "*((RV32IMACFDV*)cpu)->CSR[3104ULL] = _vl;\n";
-cp.code() += "*((RV32IMACFDV*)cpu)->CSR[3105ULL] = _vtype_result;\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[3105ULL] = vtype_result;\n";
 if (rd != 0LL) { // conditional
 cp.code() += "*((RV32IMACFDV*)cpu)->X[" + std::to_string(rd) + "ULL] = _vl;\n";
 } // conditional
@@ -431,12 +440,18 @@ cp.code() += "etiss_uint8 lmul = (vtype_extractLMUL(zimm)) & 0x7;\n";
 cp.code() += "etiss_uint8 vta = (vtype_extractTA(zimm)) & 0x1;\n";
 cp.code() += "etiss_uint8 vma = (vtype_extractMA(zimm)) & 0x1;\n";
 cp.code() += "etiss_uint32 _vlmax = 0LL;\n";
-cp.code() += "etiss_uint32 _illmask = 0LL;\n";
+cp.code() += "etiss_uint32 vtype_result = zimm;\n";
 cp.code() += "etiss_uint32 _vlen = *((RV32IMACFDV*)cpu)->CSR[3106ULL] * 8ULL;\n";
+cp.code() += "if (sew == 3ULL) { // conditional\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "vtype_result = 2147483648ULL;\n";
+cp.code() += "} // block\n";
+} // block
+cp.code() += "} // conditional\n";
 cp.code() += "if (lmul & 4ULL) { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
-cp.code() += "_illmask = 2147483648ULL;\n";
 cp.code() += "if (lmul == 6ULL) { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
@@ -454,7 +469,11 @@ cp.code() += "} // conditional\n";
 cp.code() += "else { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
-cp.code() += "_vlmax = _vlen / (8ULL << sew) / 8ULL;\n";
+{ // block
+cp.code() += "{ // block\n";
+cp.code() += "vtype_result = 2147483648ULL;\n";
+cp.code() += "} // block\n";
+} // block
 cp.code() += "} // block\n";
 } // block
 cp.code() += "} // conditional\n";
@@ -464,7 +483,6 @@ cp.code() += "} // conditional\n";
 cp.code() += "else { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
-cp.code() += "_illmask = 0LL;\n";
 cp.code() += "if (lmul == 0LL) { // conditional\n";
 { // block
 cp.code() += "{ // block\n";
@@ -541,7 +559,7 @@ cp.code() += "} // block\n";
 } // block
 cp.code() += "} // conditional\n";
 cp.code() += "*((RV32IMACFDV*)cpu)->CSR[3104ULL] = _vl;\n";
-cp.code() += "*((RV32IMACFDV*)cpu)->CSR[3105ULL] = _illmask | zimm;\n";
+cp.code() += "*((RV32IMACFDV*)cpu)->CSR[3105ULL] = vtype_result;\n";
 if (rd != 0LL) { // conditional
 cp.code() += "*((RV32IMACFDV*)cpu)->X[" + std::to_string(rd) + "ULL] = _vl;\n";
 } // conditional

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve64xInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve64xInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the RVZve64x
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve64xInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve64xInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the RVZve64x
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve64xInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve64xInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the RVZve64x
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve64xInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve64xInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the RVZve64x
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve64xInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_RVZve64xInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the RVZve64x
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_ZifenceiInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_ZifenceiInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the Zifencei
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_ZifenceiInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_ZifenceiInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the Zifencei
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_ZifenceiInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_ZifenceiInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the Zifencei
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_ZifenceiInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_ZifenceiInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the Zifencei
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_ZifenceiInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_ZifenceiInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the Zifencei
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_csrInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_csrInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the tum_csr
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_csrInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_csrInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the tum_csr
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_csrInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_csrInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the tum_csr
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_csrInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_csrInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the tum_csr
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_csrInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_csrInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the tum_csr
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_retInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_retInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the tum_ret
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_retInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_retInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the tum_ret
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_retInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_retInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the tum_ret
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_retInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_retInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the tum_ret
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_retInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_retInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the tum_ret
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_rvaInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_rvaInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the tum_rva
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_rvaInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_rvaInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the tum_rva
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_rvaInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_rvaInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the tum_rva
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_rvaInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_rvaInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the tum_rva
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_rvaInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_rvaInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the tum_rva
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_semihostingInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_semihostingInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
+ * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
  *
  * This file contains the instruction behavior models of the tum_semihosting
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_semihostingInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_semihostingInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 11:38:08 +0000.
+ * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
  *
  * This file contains the instruction behavior models of the tum_semihosting
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_semihostingInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_semihostingInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Wed, 05 Feb 2025 12:27:46 +0000.
+ * Generated on Tue, 04 Mar 2025 12:00:03 +0000.
  *
  * This file contains the instruction behavior models of the tum_semihosting
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_semihostingInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_semihostingInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 13 Jan 2025 14:27:20 +0000.
+ * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
  *
  * This file contains the instruction behavior models of the tum_semihosting
  * instruction set for the RV32IMACFDV core architecture.

--- a/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_semihostingInstr.cpp
+++ b/ArchImpl/RV32IMACFDV/RV32IMACFDV_tum_semihostingInstr.cpp
@@ -1,5 +1,5 @@
 /**
- * Generated on Mon, 20 Jan 2025 16:02:49 +0000.
+ * Generated on Tue, 21 Jan 2025 11:58:28 +0000.
  *
  * This file contains the instruction behavior models of the tum_semihosting
  * instruction set for the RV32IMACFDV core architecture.

--- a/src/jitlibs/softvector/etiss_softvector.cpp
+++ b/src/jitlibs/softvector/etiss_softvector.cpp
@@ -61,10 +61,10 @@ uint8_t etiss_vload_encoded_stride(
   uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t  pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pSTRIDE)
 {
   VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW*_vt._z_lmul;
-  uint64_t _n_emul = _vt._sew*_vt._n_lmul;
+  uint64_t _z_emul = pEEW * _vt._z_lmul;
+  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
 
-  if ((_n_emul > _z_emul*8) || (_z_emul > _n_emul*8)){
+  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)){
     return 1;
   }
 
@@ -75,6 +75,39 @@ uint8_t etiss_vload_encoded_stride(
 
   auto const eew_bytes = pEEW >> 3U;
   VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, pSTRIDE);
+
+  return (0);
+}
+
+uint8_t etiss_vload_encoded_index(
+  ETISS_CPU* const pCpu,
+  ETISS_System* const pSystem,
+  void * const * const plugin_pointers,
+  uint8_t* pV,
+  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t  pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2)
+{
+  VTYPE::VTYPE _vt(pVTYPE);
+  uint64_t _z_emul = pEEW * _vt._z_lmul;
+  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+
+  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)){
+    return 1;
+  }
+
+  uint8_t* VectorRegField = pV;
+  std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
+    (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
+  };
+
+  VInstrInfo const v_instr_info{ .lmul_num = _vt._z_lmul,
+                                 .lmul_denom = _vt._n_lmul,
+                                 .sew = _vt._sew,
+                                 .vector_length = pVL,
+                                 .vector_register_length = pVLEN,
+                                 .start_element = pVSTART,
+                                 .masked = !pVm };
+
+  VLSU::load_indices(f_readMem, VectorRegField, v_instr_info, pVd, pVs2, pMSTART, pEEW);
 
   return (0);
 }
@@ -143,12 +176,48 @@ uint8_t etiss_vload_segment_stride(
   return (0);
 }
 
+uint8_t etiss_vload_segment_index(
+  ETISS_CPU* const pCpu,
+  ETISS_System* const pSystem,
+  void * const * const plugin_pointers,
+  uint8_t* pV,
+  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2)
+{
+  VTYPE::VTYPE _vt(pVTYPE);
+  uint64_t _z_emul = pEEW * _vt._z_lmul;
+  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+
+  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)){
+    return 1;
+  }
+
+  uint8_t* VectorRegField = pV;
+  std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
+    (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
+  };
+
+  VInstrInfo const v_instr_info{ .lmul_num = _vt._z_lmul,
+                                 .lmul_denom = _vt._n_lmul,
+                                 .sew = _vt._sew,
+                                 .vector_length = pVL,
+                                 .vector_register_length = pVLEN,
+                                 .start_element = pVSTART,
+                                 .masked = !pVm };
+
+  uint64_t _moffset = pMSTART;
+  for(int i = 0; i < pNF; ++i){
+    VLSU::load_indices(f_readMem, VectorRegField, v_instr_info, pVd, pVs2, pMSTART, pEEW);
+    _moffset += pEEW >> 3;
+  }
+  return (0);
+}
+
 uint8_t etiss_vstore_encoded_unitstride(
   ETISS_CPU* const pCpu,
   ETISS_System* const pSystem,
   void * const * const plugin_pointers,
   uint8_t* pV,
-  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
+  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
 {
   VTYPE::VTYPE _vt(pVTYPE);
   uint64_t _z_emul = pEEW*_vt._z_lmul;
@@ -162,7 +231,7 @@ uint8_t etiss_vstore_encoded_unitstride(
     (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
   };
 
-  VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, eew_bytes);
+  VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVs3, pMSTART, pVSTART, pVm, eew_bytes);
 
   return (0);
 }
@@ -172,7 +241,7 @@ uint8_t etiss_vstore_encoded_stride(
   ETISS_System* const pSystem,
   void * const * const plugin_pointers,
   uint8_t* pV,
-  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride)
+  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride)
 {
   VTYPE::VTYPE _vt(pVTYPE);
   uint64_t _z_emul = pEEW*_vt._z_lmul;
@@ -186,7 +255,40 @@ uint8_t etiss_vstore_encoded_stride(
     (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
   };
 
-  VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, pStride);
+  VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVs3, pMSTART, pVSTART, pVm, pStride);
+
+  return (0);
+}
+
+uint8_t etiss_vstore_encoded_index(
+  ETISS_CPU* const pCpu,
+  ETISS_System* const pSystem,
+  void * const * const plugin_pointers,
+  uint8_t* pV,
+  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t  pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2)
+{
+  VTYPE::VTYPE _vt(pVTYPE);
+  uint64_t _z_emul = pEEW * _vt._z_lmul;
+  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+
+  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)){
+    return 1;
+  }
+
+  uint8_t* VectorRegField = pV;
+  std::function<void(size_t, uint8_t*, size_t)> f_writeMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
+    (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
+  };
+
+  VInstrInfo const v_instr_info{ .lmul_num = _vt._z_lmul,
+                                 .lmul_denom = _vt._n_lmul,
+                                 .sew = _vt._sew,
+                                 .vector_length = pVL,
+                                 .vector_register_length = pVLEN,
+                                 .start_element = pVSTART,
+                                 .masked = !pVm };
+
+  VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3, pVs2, pMSTART, pEEW);
 
   return (0);
 }
@@ -196,7 +298,7 @@ uint8_t etiss_vstore_segment_unitstride(
   ETISS_System* const pSystem,
   void * const * const plugin_pointers,
   uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
+  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
 {
   VTYPE::VTYPE _vt(pVTYPE);
   uint64_t _z_emul = pEEW * _vt._z_lmul;
@@ -204,7 +306,7 @@ uint8_t etiss_vstore_segment_unitstride(
   auto const eew_bytes = pEEW >> 3U;
 
   if ((_n_emul > _z_emul * pNF * 8) || (_z_emul * pNF > _n_emul * 8)) return 1;
-  if ((pVd + pNF*_z_emul/_n_emul) > 32) return 1;
+  if ((pVs3 + pNF*_z_emul/_n_emul) > 32) return 1;
   if (pVSTART >= pVL) return (0);
 
   uint8_t* VectorRegField = pV;
@@ -215,7 +317,7 @@ uint8_t etiss_vstore_segment_unitstride(
   uint16_t _vstart = pVSTART;
   uint64_t _moffset = pMSTART;
   for(int i = 0; i< pNF; ++i){
-    VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + (i * _z_emul / _n_emul), _moffset, _vstart, pVm, pNF * eew_bytes);
+    VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVs3 + (i * _z_emul / _n_emul), _moffset, _vstart, pVm, pNF * eew_bytes);
     _moffset += eew_bytes;
     // TODO: Why reset _vstart?
     // _vstart = 0;
@@ -228,14 +330,14 @@ uint8_t etiss_vstore_segment_stride(
   ETISS_System* const pSystem,
   void * const * const plugin_pointers,
   uint8_t* pV,
-  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride)
+  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride)
 {
   VTYPE::VTYPE _vt(pVTYPE);
   uint64_t _z_emul = pEEW * _vt._z_lmul;
   uint64_t _n_emul = _vt._sew * _vt._n_lmul;
 
   if ((_n_emul > _z_emul * pNF * 8) || (_z_emul * pNF > _n_emul * 8)) return 1;
-  if ((pVd + pNF * _z_emul / _n_emul) > 32) return 1;
+  if ((pVs3 + pNF * _z_emul / _n_emul) > 32) return 1;
   if (pVSTART >= pVL) return (0);
 
   uint8_t* VectorRegField = pV;
@@ -254,16 +356,50 @@ uint8_t etiss_vstore_segment_stride(
   // For now, we change order depending on positive/negative stride.
   if (pStride < 0){
     for(int i = 0; i < pNF; ++i) {
-      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVd + (i * _z_emul / _n_emul), _moffset, _vstart, pVm, pStride);
+      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVs3 + (i * _z_emul / _n_emul), _moffset, _vstart, pVm, pStride);
       _moffset += eew_bytes;
     }
   }
   else{
     for(int i = pNF - 1; i >= 0; --i) {
       _moffset = pMSTART + (i * eew_bytes);
-      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVd + (i * _z_emul / _n_emul), _moffset, _vstart, pVm, pStride);
+      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVs3 + (i * _z_emul / _n_emul), _moffset, _vstart, pVm, pStride);
     }
   }
+  return (0);
+}
+
+uint8_t etiss_vstore_segment_index(
+  ETISS_CPU* const pCpu,
+  ETISS_System* const pSystem,
+  void * const * const plugin_pointers,
+  uint8_t* pV,
+  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t  pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2)
+{
+  VTYPE::VTYPE _vt(pVTYPE);
+  uint64_t _z_emul = pEEW * _vt._z_lmul;
+  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+
+  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)){
+    return 1;
+  }
+
+  uint8_t* VectorRegField = pV;
+  std::function<void(size_t, uint8_t*, size_t)> f_writeMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
+    (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
+  };
+
+  VInstrInfo const v_instr_info{ .lmul_num = _vt._z_lmul,
+                                 .lmul_denom = _vt._n_lmul,
+                                 .sew = _vt._sew,
+                                 .vector_length = pVL,
+                                 .vector_register_length = pVLEN,
+                                 .start_element = pVSTART,
+                                 .masked = !pVm };
+
+
+  VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3, pVs2, pMSTART, pEEW);
+
   return (0);
 }
 

--- a/src/jitlibs/softvector/etiss_softvector.cpp
+++ b/src/jitlibs/softvector/etiss_softvector.cpp
@@ -15,11 +15,12 @@
  */
 //////////////////////////////////////////////////////////////////////////////////////
 /// \file etiss_softvector.cpp
-/// \brief C++ Source for ETISS JIT libary or independent C application. Implements a C interface when compiled to library beforehand
+/// \brief C++ Source for ETISS JIT libary or independent C application. Implements a C interface when compiled to
+/// library beforehand
 /// \date 11/23/2020
 //////////////////////////////////////////////////////////////////////////////////////
 
-//#include "softvector.h"
+// #include "softvector.h"
 #include <algorithm>
 
 #include "base/base.hpp"
@@ -32,477 +33,498 @@
 extern "C"
 {
 
-uint8_t etiss_vload_encoded_unitstride(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW * _vt._z_lmul;
-  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
-
-  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)) return 1;
-
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  auto const eew_bytes = pEEW >> 3U;
-  VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, eew_bytes);
-  return (0);
-}
-
-uint8_t etiss_vload_mask(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV, uint8_t  pVm, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
-{
-  uint8_t* VectorRegField = pV;
-
-  std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  static constexpr auto eew_bytes = 1;
-  static constexpr auto emul_num = 1;
-  static constexpr auto emul_denom = 1;
-  // evl = ceil(vl / 8)
-  auto const evl = (pVL + 7) / 8;
-  VLSU::load_eew(f_readMem, VectorRegField, emul_num, emul_denom, eew_bytes, evl, pVLEN >> 3, pVd, pMSTART, pVSTART, pVm, eew_bytes);
-  return (0);
-}
-
-uint8_t etiss_vload_encoded_stride(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t  pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pSTRIDE)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW * _vt._z_lmul;
-  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
-
-  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)){
-    return 1;
-  }
-
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  auto const eew_bytes = pEEW >> 3U;
-  VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, pSTRIDE);
-
-  return (0);
-}
-
-uint8_t etiss_vload_encoded_index(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t  pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW * _vt._z_lmul;
-  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
-
-  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)){
-    return 1;
-  }
-
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  VInstrInfo const v_instr_info{ .lmul_num = _vt._z_lmul,
-                                 .lmul_denom = _vt._n_lmul,
-                                 .sew = _vt._sew,
-                                 .vector_length = pVL,
-                                 .vector_register_length = pVLEN,
-                                 .start_element = pVSTART,
-                                 .masked = !pVm };
-
-  VLSU::load_indices(f_readMem, VectorRegField, v_instr_info, pVd, pVs2, pMSTART, pEEW);
-
-  return (0);
-}
-
-uint8_t etiss_vload_segment_unitstride(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW*_vt._z_lmul;
-  uint64_t _n_emul = _vt._sew*_vt._n_lmul;
-
-  if ((_n_emul > _z_emul*pNF*8) || (_z_emul*pNF > _n_emul*8)) return 1;
-  if ((pVd + pNF*_z_emul/_n_emul) > 32) return 1;
-  if (pVSTART >= pVL) return (0);
-
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  uint16_t _vstart = pVSTART;
-  uint64_t _moffset = pMSTART;
-  auto const eew_bytes = pEEW >> 3U;
-
-  for(size_t i = 0; i < pNF; ++i){
-    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + std::max(i, i * (_vt._z_lmul / _vt._n_lmul)), _moffset, _vstart, pVm, pNF * eew_bytes);
-    _moffset += eew_bytes;
-    // _vstart = 0;
-  }
-  return (0);
-}
-
-uint8_t etiss_vload_segment_stride(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pSTRIDE)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW*_vt._z_lmul;
-  uint64_t _n_emul = _vt._sew*_vt._n_lmul;
-
-  if ((_n_emul > _z_emul*pNF*8) || (_z_emul*pNF > _n_emul*8)) return 1;
-  if ((pVd + pNF*_z_emul/_n_emul) > 32) return 1;
-  if (pVSTART >= pVL) return (0);
-
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  uint16_t _vstart = pVSTART;
-  uint64_t _moffset = pMSTART;
-  auto const eew_bytes = pEEW >> 3U;
-
-  for(size_t i = 0; i < pNF; ++i){
-    _moffset = pMSTART + i * (eew_bytes);
-    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + std::max(i, i * (_vt._z_lmul / _vt._n_lmul)), _moffset, _vstart, pVm, pSTRIDE);
-    // _vstart = 0;
-  }
-  return (0);
-}
-
-uint8_t etiss_vload_segment_index(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW * _vt._z_lmul;
-  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
-
-  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)){
-    return 1;
-  }
-
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  VInstrInfo const v_instr_info{ .lmul_num = _vt._z_lmul,
-                                 .lmul_denom = _vt._n_lmul,
-                                 .sew = _vt._sew,
-                                 .vector_length = pVL,
-                                 .vector_register_length = pVLEN,
-                                 .start_element = pVSTART,
-                                 .masked = !pVm };
-
-  uint64_t _moffset = pMSTART;
-  for(size_t i = 0; i < pNF; ++i){
-    VLSU::load_indices(f_readMem, VectorRegField, v_instr_info, pVd + std::max(i, i * (_vt._z_lmul / _vt._n_lmul)), pVs2, _moffset, pEEW);
-    _moffset += _vt._sew >> 3;
-  }
-  return (0);
-}
-
-uint8_t etiss_vload_registers(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint64_t pMSTART)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pNF;
-  uint64_t _n_emul = 1;
-
-  if ((_n_emul > _z_emul*8) || (_z_emul > _n_emul*8)) return 1;
-
-  auto evl = pNF * (pVLEN / pEEW);
-
-  if (evl <= pVSTART) {
-    return 0;
-  }
-
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  auto const eew_bytes = pEEW >> 3U;
-  VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, evl, pVLEN/8, pVd, pMSTART, pVSTART, pVm, eew_bytes);
-  return (0);
-}
-
-uint8_t etiss_vstore_encoded_unitstride(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW*_vt._z_lmul;
-  uint64_t _n_emul = _vt._sew*_vt._n_lmul;
-  auto const eew_bytes = pEEW >> 3U;
-
-  if ((_n_emul > _z_emul*8) || (_z_emul > _n_emul*8)) return 1;
-
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_writeMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVs3, pMSTART, pVSTART, pVm, eew_bytes);
-
-  return (0);
-}
-
-uint8_t etiss_vstore_mask(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV, uint8_t pVm, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
-{
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_writeMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  static constexpr auto eew_bytes = 1;
-  static constexpr auto emul_num = 1;
-  static constexpr auto emul_denom = 1;
-  // evl = ceil(vl / 8)
-  auto const evl = (pVL + 7) / 8;
-
-  VLSU::store_eew(f_writeMem, VectorRegField, emul_num, emul_denom, eew_bytes, evl, pVLEN >> 3, pVs3, pMSTART, pVSTART, pVm, eew_bytes);
-
-  return (0);
-}
-
-uint8_t etiss_vstore_encoded_stride(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW*_vt._z_lmul;
-  uint64_t _n_emul = _vt._sew*_vt._n_lmul;
-  auto const eew_bytes = pEEW >> 3U;
-
-  if ((_n_emul > _z_emul*8) || (_z_emul > _n_emul*8)) return 1;
-
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_writeMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVs3, pMSTART, pVSTART, pVm, pStride);
-
-  return (0);
-}
-
-uint8_t etiss_vstore_encoded_index(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t  pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW * _vt._z_lmul;
-  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
-
-  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)){
-    return 1;
-  }
-
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_writeMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  VInstrInfo const v_instr_info{ .lmul_num = _vt._z_lmul,
-                                 .lmul_denom = _vt._n_lmul,
-                                 .sew = _vt._sew,
-                                 .vector_length = pVL,
-                                 .vector_register_length = pVLEN,
-                                 .start_element = pVSTART,
-                                 .masked = !pVm };
-
-  VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3, pVs2, pMSTART, pEEW, 1);
-
-  return (0);
-}
-
-uint8_t etiss_vstore_segment_unitstride(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW * _vt._z_lmul;
-  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
-  auto const eew_bytes = pEEW >> 3U;
-
-  if ((_n_emul > _z_emul * pNF * 8) || (_z_emul * pNF > _n_emul * 8)) return 1;
-  if ((pVs3 + pNF*_z_emul/_n_emul) > 32) return 1;
-  if (pVSTART >= pVL) return (0);
-
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_writeMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  uint16_t _vstart = pVSTART;
-  uint64_t _moffset = pMSTART;
-  for(size_t i = 0; i < pNF; ++i){
-    VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVs3 + std::max(i, (i * _z_emul / _n_emul)), _moffset, _vstart, pVm, pNF * eew_bytes);
-    _moffset += eew_bytes;
-    // TODO: Why reset _vstart?
-    // _vstart = 0;
-  }
-  return (0);
-}
-
-uint8_t etiss_vstore_segment_stride(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW * _vt._z_lmul;
-  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
-
-  if ((_n_emul > _z_emul * pNF * 8) || (_z_emul * pNF > _n_emul * 8)) return 1;
-  if ((pVs3 + pNF * _z_emul / _n_emul) > 32) return 1;
-  if (pVSTART >= pVL) return (0);
-
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_writeMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
-  };
-
-  uint16_t _vstart = pVSTART;
-  uint64_t _moffset = pMSTART;
-  auto const eew_bytes = pEEW >> 3U;
-
-  // Memory order problem: 
-  // Which stores come first? According to the spec: 
-  // "Accesses to the fields within each segment can occur in any order, 
-  // including the case where the byte stride is such that segments overlap in memory."
-  // For now, we change order depending on positive/negative stride.
-  if (pStride < 0){
-    for(size_t i = 0; i < pNF; ++i) {
-      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVs3 + std::max(i, (i * _z_emul / _n_emul)), _moffset, _vstart, pVm, pStride);
-      _moffset += eew_bytes;
+    uint8_t etiss_vload_encoded_unitstride(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                           void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE,
+                                           uint8_t pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN,
+                                           uint16_t pVL, uint64_t pMSTART)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pEEW * _vt._z_lmul;
+        uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+
+        if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8))
+            return 1;
+
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_readMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len); };
+
+        auto const eew_bytes = pEEW >> 3U;
+        VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVd, pMSTART, pVSTART,
+                       pVm, eew_bytes);
+        return (0);
     }
-  }
-  else{
-    for(size_t i = pNF; i > 0; --i) {
-      _moffset = pMSTART + ((i - 1) * eew_bytes);
-      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVs3 + std::max((i - 1), ((i - 1) * _z_emul / _n_emul)), _moffset, _vstart, pVm, pStride);
+
+    uint8_t etiss_vload_mask(ETISS_CPU *const pCpu, ETISS_System *const pSystem, void *const *const plugin_pointers,
+                             uint8_t *pV, uint8_t pVm, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL,
+                             uint64_t pMSTART)
+    {
+        uint8_t *VectorRegField = pV;
+
+        std::function<void(size_t, uint8_t *, size_t)> f_readMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len); };
+
+        static constexpr auto eew_bytes = 1;
+        static constexpr auto emul_num = 1;
+        static constexpr auto emul_denom = 1;
+        // evl = ceil(vl / 8)
+        auto const evl = (pVL + 7) / 8;
+        VLSU::load_eew(f_readMem, VectorRegField, emul_num, emul_denom, eew_bytes, evl, pVLEN >> 3, pVd, pMSTART,
+                       pVSTART, pVm, eew_bytes);
+        return (0);
     }
-  }
-  return (0);
-}
 
-uint8_t etiss_vstore_segment_index(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t  pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW * _vt._z_lmul;
-  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+    uint8_t etiss_vload_encoded_stride(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                       void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                       uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL,
+                                       uint64_t pMSTART, int16_t pSTRIDE)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pEEW * _vt._z_lmul;
+        uint64_t _n_emul = _vt._sew * _vt._n_lmul;
 
-  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)){
-    return 1;
-  }
+        if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8))
+        {
+            return 1;
+        }
 
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_writeMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
-  };
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_readMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len); };
 
-  VInstrInfo const v_instr_info{ .lmul_num = _vt._z_lmul,
-                                 .lmul_denom = _vt._n_lmul,
-                                 .sew = _vt._sew,
-                                 .vector_length = pVL,
-                                 .vector_register_length = pVLEN,
-                                 .start_element = pVSTART,
-                                 .masked = !pVm };
+        auto const eew_bytes = pEEW >> 3U;
+        VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVd, pMSTART, pVSTART,
+                       pVm, pSTRIDE);
 
-  VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3, pVs2, pMSTART, pEEW, pNF);
+        return (0);
+    }
 
-  return (0);
-}
+    uint8_t etiss_vload_encoded_index(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                      void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                      uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL,
+                                      uint64_t pMSTART, uint8_t pVs2)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pEEW * _vt._z_lmul;
+        uint64_t _n_emul = _vt._sew * _vt._n_lmul;
 
-uint8_t etiss_vstore_registers(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t pVm, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint64_t pMSTART)
-{
-  VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pNF;
-  uint64_t _n_emul = 1;
+        if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8))
+        {
+            return 1;
+        }
 
-  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)) return 1;
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_readMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len); };
 
-  auto evl = pNF * (pVLEN >> 3);
+        auto v_instr_info = VInstrInfo{};
 
-  if (evl <= pVSTART) {
-    return 0;
-  }
+        v_instr_info.lmul_num = _vt._z_lmul;
+        v_instr_info.lmul_denom = _vt._n_lmul;
+        v_instr_info.sew = _vt._sew;
+        v_instr_info.vector_length = pVL;
+        v_instr_info.vector_register_length = pVLEN;
+        v_instr_info.start_element = pVSTART;
+        v_instr_info.masked = !pVm;
 
-  uint8_t* VectorRegField = pV;
-  std::function<void(size_t, uint8_t*, size_t)> f_writeMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
-    (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
-  };
+        VLSU::load_indices(f_readMem, VectorRegField, v_instr_info, pVd, pVs2, pMSTART, pEEW);
 
-  VLSU::store_eew(f_writeMem, VectorRegField, pNF, 1, 1, evl, pVLEN/8, pVs3, pMSTART, pVSTART, pVm, 1);
+        return (0);
+    }
 
-  return (0);
-}
+    uint8_t etiss_vload_segment_unitstride(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                           void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE,
+                                           uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART,
+                                           uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pEEW * _vt._z_lmul;
+        uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+
+        if ((_n_emul > _z_emul * pNF * 8) || (_z_emul * pNF > _n_emul * 8))
+            return 1;
+        if ((pVd + pNF * _z_emul / _n_emul) > 32)
+            return 1;
+        if (pVSTART >= pVL)
+            return (0);
+
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_readMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len); };
+
+        uint16_t _vstart = pVSTART;
+        uint64_t _moffset = pMSTART;
+        auto const eew_bytes = pEEW >> 3U;
+
+        for (size_t i = 0; i < pNF; ++i)
+        {
+            VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8,
+                           pVd + std::max(i, i * (_vt._z_lmul / _vt._n_lmul)), _moffset, _vstart, pVm, pNF * eew_bytes);
+            _moffset += eew_bytes;
+            // _vstart = 0;
+        }
+        return (0);
+    }
+
+    uint8_t etiss_vload_segment_stride(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                       void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                       uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN,
+                                       uint16_t pVL, uint64_t pMSTART, int16_t pSTRIDE)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pEEW * _vt._z_lmul;
+        uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+
+        if ((_n_emul > _z_emul * pNF * 8) || (_z_emul * pNF > _n_emul * 8))
+            return 1;
+        if ((pVd + pNF * _z_emul / _n_emul) > 32)
+            return 1;
+        if (pVSTART >= pVL)
+            return (0);
+
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_readMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len); };
+
+        uint16_t _vstart = pVSTART;
+        uint64_t _moffset = pMSTART;
+        auto const eew_bytes = pEEW >> 3U;
+
+        for (size_t i = 0; i < pNF; ++i)
+        {
+            _moffset = pMSTART + i * (eew_bytes);
+            VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8,
+                           pVd + std::max(i, i * (_vt._z_lmul / _vt._n_lmul)), _moffset, _vstart, pVm, pSTRIDE);
+            // _vstart = 0;
+        }
+        return (0);
+    }
+
+    uint8_t etiss_vload_segment_index(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                      void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                      uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN,
+                                      uint16_t pVL, uint64_t pMSTART, uint8_t pVs2)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pEEW * _vt._z_lmul;
+        uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+
+        if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8))
+        {
+            return 1;
+        }
+
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_readMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len); };
+
+        auto v_instr_info = VInstrInfo{};
+
+        v_instr_info.lmul_num = _vt._z_lmul;
+        v_instr_info.lmul_denom = _vt._n_lmul;
+        v_instr_info.sew = _vt._sew;
+        v_instr_info.vector_length = pVL;
+        v_instr_info.vector_register_length = pVLEN;
+        v_instr_info.start_element = pVSTART;
+        v_instr_info.masked = !pVm;
+
+        uint64_t _moffset = pMSTART;
+        for (size_t i = 0; i < pNF; ++i)
+        {
+            VLSU::load_indices(f_readMem, VectorRegField, v_instr_info,
+                               pVd + std::max(i, i * (_vt._z_lmul / _vt._n_lmul)), pVs2, _moffset, pEEW);
+            _moffset += _vt._sew >> 3;
+        }
+        return (0);
+    }
+
+    uint8_t etiss_vload_registers(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                  void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                  uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN,
+                                  uint64_t pMSTART)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pNF;
+        uint64_t _n_emul = 1;
+
+        if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8))
+            return 1;
+
+        auto evl = pNF * (pVLEN / pEEW);
+
+        if (evl <= pVSTART)
+        {
+            return 0;
+        }
+
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_readMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len); };
+
+        auto const eew_bytes = pEEW >> 3U;
+        VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, evl, pVLEN / 8, pVd, pMSTART, pVSTART,
+                       pVm, eew_bytes);
+        return (0);
+    }
+
+    uint8_t etiss_vstore_encoded_unitstride(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                            void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE,
+                                            uint8_t pVm, uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN,
+                                            uint16_t pVL, uint64_t pMSTART)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pEEW * _vt._z_lmul;
+        uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+        auto const eew_bytes = pEEW >> 3U;
+
+        if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8))
+            return 1;
+
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_writeMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len); };
+
+        VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVs3, pMSTART, pVSTART,
+                        pVm, eew_bytes);
+
+        return (0);
+    }
+
+    uint8_t etiss_vstore_mask(ETISS_CPU *const pCpu, ETISS_System *const pSystem, void *const *const plugin_pointers,
+                              uint8_t *pV, uint8_t pVm, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL,
+                              uint64_t pMSTART)
+    {
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_writeMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len); };
+
+        static constexpr auto eew_bytes = 1;
+        static constexpr auto emul_num = 1;
+        static constexpr auto emul_denom = 1;
+        // evl = ceil(vl / 8)
+        auto const evl = (pVL + 7) / 8;
+
+        VLSU::store_eew(f_writeMem, VectorRegField, emul_num, emul_denom, eew_bytes, evl, pVLEN >> 3, pVs3, pMSTART,
+                        pVSTART, pVm, eew_bytes);
+
+        return (0);
+    }
+
+    uint8_t etiss_vstore_encoded_stride(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                        void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                        uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL,
+                                        uint64_t pMSTART, int16_t pStride)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pEEW * _vt._z_lmul;
+        uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+        auto const eew_bytes = pEEW >> 3U;
+
+        if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8))
+            return 1;
+
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_writeMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len); };
+
+        VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVs3, pMSTART, pVSTART,
+                        pVm, pStride);
+
+        return (0);
+    }
+
+    uint8_t etiss_vstore_encoded_index(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                       void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                       uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL,
+                                       uint64_t pMSTART, uint8_t pVs2)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pEEW * _vt._z_lmul;
+        uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+
+        if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8))
+        {
+            return 1;
+        }
+
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_writeMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len); };
+
+        auto v_instr_info = VInstrInfo{};
+
+        v_instr_info.lmul_num = _vt._z_lmul;
+        v_instr_info.lmul_denom = _vt._n_lmul;
+        v_instr_info.sew = _vt._sew;
+        v_instr_info.vector_length = pVL;
+        v_instr_info.vector_register_length = pVLEN;
+        v_instr_info.start_element = pVSTART;
+        v_instr_info.masked = !pVm;
+
+        VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3, pVs2, pMSTART, pEEW, 1);
+
+        return (0);
+    }
+
+    uint8_t etiss_vstore_segment_unitstride(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                            void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE,
+                                            uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART,
+                                            uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pEEW * _vt._z_lmul;
+        uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+        auto const eew_bytes = pEEW >> 3U;
+
+        if ((_n_emul > _z_emul * pNF * 8) || (_z_emul * pNF > _n_emul * 8))
+            return 1;
+        if ((pVs3 + pNF * _z_emul / _n_emul) > 32)
+            return 1;
+        if (pVSTART >= pVL)
+            return (0);
+
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_writeMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len); };
+
+        uint16_t _vstart = pVSTART;
+        uint64_t _moffset = pMSTART;
+        for (size_t i = 0; i < pNF; ++i)
+        {
+            VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8,
+                            pVs3 + std::max(i, (i * _z_emul / _n_emul)), _moffset, _vstart, pVm, pNF * eew_bytes);
+            _moffset += eew_bytes;
+            // TODO: Why reset _vstart?
+            // _vstart = 0;
+        }
+        return (0);
+    }
+
+    uint8_t etiss_vstore_segment_stride(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                        void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                        uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN,
+                                        uint16_t pVL, uint64_t pMSTART, int16_t pStride)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pEEW * _vt._z_lmul;
+        uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+
+        if ((_n_emul > _z_emul * pNF * 8) || (_z_emul * pNF > _n_emul * 8))
+            return 1;
+        if ((pVs3 + pNF * _z_emul / _n_emul) > 32)
+            return 1;
+        if (pVSTART >= pVL)
+            return (0);
+
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_writeMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len); };
+
+        uint16_t _vstart = pVSTART;
+        uint64_t _moffset = pMSTART;
+        auto const eew_bytes = pEEW >> 3U;
+
+        // Memory order problem:
+        // Which stores come first? According to the spec:
+        // "Accesses to the fields within each segment can occur in any order,
+        // including the case where the byte stride is such that segments overlap in memory."
+        // For now, we change order depending on positive/negative stride.
+        if (pStride < 0)
+        {
+            for (size_t i = 0; i < pNF; ++i)
+            {
+                VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8,
+                                pVs3 + std::max(i, (i * _z_emul / _n_emul)), _moffset, _vstart, pVm, pStride);
+                _moffset += eew_bytes;
+            }
+        }
+        else
+        {
+            for (size_t i = pNF; i > 0; --i)
+            {
+                _moffset = pMSTART + ((i - 1) * eew_bytes);
+                VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8,
+                                pVs3 + std::max((i - 1), ((i - 1) * _z_emul / _n_emul)), _moffset, _vstart, pVm,
+                                pStride);
+            }
+        }
+        return (0);
+    }
+
+    uint8_t etiss_vstore_segment_index(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                       void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                       uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN,
+                                       uint16_t pVL, uint64_t pMSTART, uint8_t pVs2)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pEEW * _vt._z_lmul;
+        uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+
+        if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8))
+        {
+            return 1;
+        }
+
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_writeMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len); };
+
+        auto v_instr_info = VInstrInfo{};
+
+        v_instr_info.lmul_num = _vt._z_lmul;
+        v_instr_info.lmul_denom = _vt._n_lmul;
+        v_instr_info.sew = _vt._sew;
+        v_instr_info.vector_length = pVL;
+        v_instr_info.vector_register_length = pVLEN;
+        v_instr_info.start_element = pVSTART;
+        v_instr_info.masked = !pVm;
+
+        VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3, pVs2, pMSTART, pEEW, pNF);
+
+        return (0);
+    }
+
+    uint8_t etiss_vstore_registers(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                   void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                   uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint64_t pMSTART)
+    {
+        VTYPE::VTYPE _vt(pVTYPE);
+        uint64_t _z_emul = pNF;
+        uint64_t _n_emul = 1;
+
+        if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8))
+            return 1;
+
+        auto evl = pNF * (pVLEN >> 3);
+
+        if (evl <= pVSTART)
+        {
+            return 0;
+        }
+
+        uint8_t *VectorRegField = pV;
+        std::function<void(size_t, uint8_t *, size_t)> f_writeMem =
+            [pSystem, pCpu](size_t addr, uint8_t *buff, size_t len)
+        { (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len); };
+
+        VLSU::store_eew(f_writeMem, VectorRegField, pNF, 1, 1, evl, pVLEN / 8, pVs3, pMSTART, pVSTART, pVm, 1);
+
+        return (0);
+    }
 
 } // extern "C"

--- a/src/jitlibs/softvector/etiss_softvector.cpp
+++ b/src/jitlibs/softvector/etiss_softvector.cpp
@@ -139,7 +139,7 @@ uint8_t etiss_vload_segment_unitstride(
   auto const eew_bytes = pEEW >> 3U;
 
   for(size_t i = 0; i < pNF; ++i){
-    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + std::max(i, i * (_z_emul/_n_emul)), _moffset, _vstart, pVm, pNF * eew_bytes);
+    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + std::max(i, i * (_vt._z_lmul / _vt._n_lmul)), _moffset, _vstart, pVm, pNF * eew_bytes);
     _moffset += eew_bytes;
     // _vstart = 0;
   }
@@ -172,7 +172,7 @@ uint8_t etiss_vload_segment_stride(
 
   for(size_t i = 0; i < pNF; ++i){
     _moffset = pMSTART + i * (eew_bytes);
-    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + std::max(i, i * (_z_emul/_n_emul)), _moffset, _vstart, pVm, pSTRIDE);
+    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + std::max(i, i * (_vt._z_lmul / _vt._n_lmul)), _moffset, _vstart, pVm, pSTRIDE);
     // _vstart = 0;
   }
   return (0);
@@ -208,8 +208,8 @@ uint8_t etiss_vload_segment_index(
 
   uint64_t _moffset = pMSTART;
   for(size_t i = 0; i < pNF; ++i){
-    VLSU::load_indices(f_readMem, VectorRegField, v_instr_info, pVd + std::max(i, i * (_z_emul/_n_emul)), pVs2, pMSTART, pEEW);
-    _moffset += pEEW >> 3;
+    VLSU::load_indices(f_readMem, VectorRegField, v_instr_info, pVd + std::max(i, i * (_vt._z_lmul / _vt._n_lmul)), pVs2, _moffset, pEEW);
+    _moffset += _vt._sew >> 3;
   }
   return (0);
 }
@@ -399,9 +399,12 @@ uint8_t etiss_vstore_segment_index(
                                  .start_element = pVSTART,
                                  .masked = !pVm };
 
+  uint64_t _moffset = pMSTART;
+
   for (size_t i = 0; i < pNF; i++)
   {
-    VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3 + + std::max(i, (i * _z_emul / _n_emul)), pVs2, pMSTART, pEEW);
+    VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3 + std::max(i, (i * _z_emul / _n_emul)), pVs2, _moffset, pEEW);
+    _moffset += _vt._sew >> 3;
   }
   
 

--- a/src/jitlibs/softvector/etiss_softvector.cpp
+++ b/src/jitlibs/softvector/etiss_softvector.cpp
@@ -206,9 +206,10 @@ uint8_t etiss_vstore_segment_unitstride(
   uint16_t _vstart = pVSTART;
   uint64_t _moffset = pMSTART;
   for(int i = 0; i< pNF; ++i){
-    VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd + (i*_z_emul/_n_emul), _moffset, _vstart, pVm, 0);
-    _moffset+= (pVL-_vstart)*pEEW/8;
-    _vstart = 0;
+    VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd + (i*_z_emul/_n_emul), _moffset, _vstart, pVm, pNF * (pEEW/8));
+    _moffset+= pEEW/8;
+    // TODO: Why reset _vstart?
+    // _vstart = 0;
   }
   return (0);
 }

--- a/src/jitlibs/softvector/etiss_softvector.cpp
+++ b/src/jitlibs/softvector/etiss_softvector.cpp
@@ -214,6 +214,35 @@ uint8_t etiss_vload_segment_index(
   return (0);
 }
 
+uint8_t etiss_vload_registers(
+  ETISS_CPU* const pCpu,
+  ETISS_System* const pSystem,
+  void * const * const plugin_pointers,
+  uint8_t* pV,
+  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint64_t pMSTART)
+{
+  VTYPE::VTYPE _vt(pVTYPE);
+  uint64_t _z_emul = pNF;
+  uint64_t _n_emul = 1;
+
+  if ((_n_emul > _z_emul*8) || (_z_emul > _n_emul*8)) return 1;
+
+  auto evl = pNF * (pVLEN / pEEW);
+
+  if (evl <= pVSTART) {
+    return 0;
+  }
+
+  uint8_t* VectorRegField = pV;
+  std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
+    (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
+  };
+
+  auto const eew_bytes = pEEW >> 3U;
+  VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, evl, pVLEN/8, pVd, pMSTART, pVSTART, pVm, eew_bytes);
+  return (0);
+}
+
 uint8_t etiss_vstore_encoded_unitstride(
   ETISS_CPU* const pCpu,
   ETISS_System* const pSystem,
@@ -290,7 +319,7 @@ uint8_t etiss_vstore_encoded_index(
                                  .start_element = pVSTART,
                                  .masked = !pVm };
 
-  VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3, pVs2, pMSTART, pEEW);
+  VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3, pVs2, pMSTART, pEEW, 1);
 
   return (0);
 }
@@ -399,14 +428,36 @@ uint8_t etiss_vstore_segment_index(
                                  .start_element = pVSTART,
                                  .masked = !pVm };
 
-  uint64_t _moffset = pMSTART;
+  VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3, pVs2, pMSTART, pEEW, pNF);
 
-  for (size_t i = 0; i < pNF; i++)
-  {
-    VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3 + std::max(i, (i * _z_emul / _n_emul)), pVs2, _moffset, pEEW);
-    _moffset += _vt._sew >> 3;
+  return (0);
+}
+
+uint8_t etiss_vstore_registers(
+  ETISS_CPU* const pCpu,
+  ETISS_System* const pSystem,
+  void * const * const plugin_pointers,
+  uint8_t* pV,
+  uint16_t pVTYPE, uint8_t pVm, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint64_t pMSTART)
+{
+  VTYPE::VTYPE _vt(pVTYPE);
+  uint64_t _z_emul = pNF;
+  uint64_t _n_emul = 1;
+
+  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)) return 1;
+
+  auto evl = pNF * (pVLEN >> 3);
+
+  if (evl <= pVSTART) {
+    return 0;
   }
-  
+
+  uint8_t* VectorRegField = pV;
+  std::function<void(size_t, uint8_t*, size_t)> f_writeMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
+    (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
+  };
+
+  VLSU::store_eew(f_writeMem, VectorRegField, pNF, 1, 1, evl, pVLEN/8, pVs3, pMSTART, pVSTART, pVm, 1);
 
   return (0);
 }

--- a/src/jitlibs/softvector/etiss_softvector.cpp
+++ b/src/jitlibs/softvector/etiss_softvector.cpp
@@ -48,7 +48,8 @@ uint8_t etiss_vload_encoded_unitstride(
     (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
   };
 
-  VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, pEEW/8);
+  auto const eew_bytes = pEEW >> 3U;
+  VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, eew_bytes);
   return (0);
 }
 
@@ -72,7 +73,8 @@ uint8_t etiss_vload_encoded_stride(
     (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
   };
 
-  VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, pSTRIDE);
+  auto const eew_bytes = pEEW >> 3U;
+  VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, pSTRIDE);
 
   return (0);
 }
@@ -99,10 +101,12 @@ uint8_t etiss_vload_segment_unitstride(
 
   uint16_t _vstart = pVSTART;
   uint64_t _moffset = pMSTART;
-  for(int i = 0; i< pNF; ++i){
-    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd + (i*_z_emul/_n_emul), _moffset, _vstart, pVm, 0);
-    _moffset+= (pVL-_vstart)*pEEW/8;
-    _vstart = 0;
+  auto const eew_bytes = pEEW >> 3U;
+
+  for(int i = 0; i < pNF; ++i){
+    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + (i*_z_emul/_n_emul), _moffset, _vstart, pVm, pNF * eew_bytes);
+    _moffset += eew_bytes;
+    // _vstart = 0;
   }
   return (0);
 }
@@ -129,10 +133,12 @@ uint8_t etiss_vload_segment_stride(
 
   uint16_t _vstart = pVSTART;
   uint64_t _moffset = pMSTART;
-  for(int i = 0; i< pNF; ++i){
-    _moffset = pMSTART + i*pEEW/8;
-    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd + (i*_z_emul/_n_emul), _moffset, _vstart, pVm, pSTRIDE);
-    _vstart = 0;
+  auto const eew_bytes = pEEW >> 3U;
+
+  for(int i = 0; i < pNF; ++i){
+    _moffset = pMSTART + i * (eew_bytes);
+    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + (i*_z_emul/_n_emul), _moffset, _vstart, pVm, pSTRIDE);
+    // _vstart = 0;
   }
   return (0);
 }
@@ -147,6 +153,7 @@ uint8_t etiss_vstore_encoded_unitstride(
   VTYPE::VTYPE _vt(pVTYPE);
   uint64_t _z_emul = pEEW*_vt._z_lmul;
   uint64_t _n_emul = _vt._sew*_vt._n_lmul;
+  auto const eew_bytes = pEEW >> 3U;
 
   if ((_n_emul > _z_emul*8) || (_z_emul > _n_emul*8)) return 1;
 
@@ -155,7 +162,7 @@ uint8_t etiss_vstore_encoded_unitstride(
     (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
   };
 
-  VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, pEEW/8);
+  VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, eew_bytes);
 
   return (0);
 }
@@ -170,6 +177,7 @@ uint8_t etiss_vstore_encoded_stride(
   VTYPE::VTYPE _vt(pVTYPE);
   uint64_t _z_emul = pEEW*_vt._z_lmul;
   uint64_t _n_emul = _vt._sew*_vt._n_lmul;
+  auto const eew_bytes = pEEW >> 3U;
 
   if ((_n_emul > _z_emul*8) || (_z_emul > _n_emul*8)) return 1;
 
@@ -178,7 +186,7 @@ uint8_t etiss_vstore_encoded_stride(
     (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
   };
 
-  VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, pStride);
+  VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, pStride);
 
   return (0);
 }
@@ -191,10 +199,11 @@ uint8_t etiss_vstore_segment_unitstride(
   uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
 {
   VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW*_vt._z_lmul;
-  uint64_t _n_emul = _vt._sew*_vt._n_lmul;
+  uint64_t _z_emul = pEEW * _vt._z_lmul;
+  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
+  auto const eew_bytes = pEEW >> 3U;
 
-  if ((_n_emul > _z_emul*pNF*8) || (_z_emul*pNF > _n_emul*8)) return 1;
+  if ((_n_emul > _z_emul * pNF * 8) || (_z_emul * pNF > _n_emul * 8)) return 1;
   if ((pVd + pNF*_z_emul/_n_emul) > 32) return 1;
   if (pVSTART >= pVL) return (0);
 
@@ -206,8 +215,8 @@ uint8_t etiss_vstore_segment_unitstride(
   uint16_t _vstart = pVSTART;
   uint64_t _moffset = pMSTART;
   for(int i = 0; i< pNF; ++i){
-    VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd + (i*_z_emul/_n_emul), _moffset, _vstart, pVm, pNF * (pEEW/8));
-    _moffset+= pEEW/8;
+    VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + (i * _z_emul / _n_emul), _moffset, _vstart, pVm, pNF * eew_bytes);
+    _moffset += eew_bytes;
     // TODO: Why reset _vstart?
     // _vstart = 0;
   }
@@ -222,11 +231,11 @@ uint8_t etiss_vstore_segment_stride(
   uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride)
 {
   VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW*_vt._z_lmul;
-  uint64_t _n_emul = _vt._sew*_vt._n_lmul;
+  uint64_t _z_emul = pEEW * _vt._z_lmul;
+  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
 
-  if ((_n_emul > _z_emul*pNF*8) || (_z_emul*pNF > _n_emul*8)) return 1;
-  if ((pVd + pNF*_z_emul/_n_emul) > 32) return 1;
+  if ((_n_emul > _z_emul * pNF * 8) || (_z_emul * pNF > _n_emul * 8)) return 1;
+  if ((pVd + pNF * _z_emul / _n_emul) > 32) return 1;
   if (pVSTART >= pVL) return (0);
 
   uint8_t* VectorRegField = pV;
@@ -236,6 +245,7 @@ uint8_t etiss_vstore_segment_stride(
 
   uint16_t _vstart = pVSTART;
   uint64_t _moffset = pMSTART;
+  auto const eew_bytes = pEEW >> 3U;
 
   // Memory order problem: 
   // Which stores come first? According to the spec: 
@@ -243,18 +253,15 @@ uint8_t etiss_vstore_segment_stride(
   // including the case where the byte stride is such that segments overlap in memory."
   // For now, we change order depending on positive/negative stride.
   if (pStride < 0){
-    for(int i = 0; i < pNF; i++) {
-      // _moffset = pMSTART + i*pEEW/8;
-      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd + (i*_z_emul/_n_emul), _moffset, _vstart, pVm, pStride);
-      _moffset+= pEEW/8;
-      // _vstart = 0;
+    for(int i = 0; i < pNF; ++i) {
+      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVd + (i * _z_emul / _n_emul), _moffset, _vstart, pVm, pStride);
+      _moffset += eew_bytes;
     }
   }
   else{
-    for(int i = pNF - 1; i >= 0; i--) {
-      _moffset = pMSTART + i * (pEEW / 8);
-      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd + (i * (_z_emul / _n_emul)), _moffset, _vstart, pVm, pStride);
-      // _vstart = 0;
+    for(int i = pNF - 1; i >= 0; --i) {
+      _moffset = pMSTART + (i * eew_bytes);
+      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVd + (i * _z_emul / _n_emul), _moffset, _vstart, pVm, pStride);
     }
   }
   return (0);

--- a/src/jitlibs/softvector/etiss_softvector.cpp
+++ b/src/jitlibs/softvector/etiss_softvector.cpp
@@ -37,13 +37,13 @@ uint8_t etiss_vload_encoded_unitstride(
   ETISS_System* const pSystem,
   void * const * const plugin_pointers,
   uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t  pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
+  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
 {
   VTYPE::VTYPE _vt(pVTYPE);
-  uint64_t _z_emul = pEEW*_vt._z_lmul;
-  uint64_t _n_emul = _vt._sew*_vt._n_lmul;
+  uint64_t _z_emul = pEEW * _vt._z_lmul;
+  uint64_t _n_emul = _vt._sew * _vt._n_lmul;
 
-  if ((_n_emul > _z_emul*8) || (_z_emul > _n_emul*8)) return 1;
+  if ((_n_emul > _z_emul * 8) || (_z_emul > _n_emul * 8)) return 1;
 
   uint8_t* VectorRegField = pV;
   std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
@@ -52,6 +52,27 @@ uint8_t etiss_vload_encoded_unitstride(
 
   auto const eew_bytes = pEEW >> 3U;
   VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd, pMSTART, pVSTART, pVm, eew_bytes);
+  return (0);
+}
+
+uint8_t etiss_vload_mask(
+  ETISS_CPU* const pCpu,
+  ETISS_System* const pSystem,
+  void * const * const plugin_pointers,
+  uint8_t* pV, uint8_t  pVm, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
+{
+  uint8_t* VectorRegField = pV;
+
+  std::function<void(size_t, uint8_t*, size_t)> f_readMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
+    (*(pSystem->dread))(pSystem->handle, pCpu, addr, buff, len);
+  };
+
+  static constexpr auto eew_bytes = 1;
+  static constexpr auto emul_num = 1;
+  static constexpr auto emul_denom = 1;
+  // evl = ceil(vl / 8)
+  auto const evl = (pVL + 7) / 8;
+  VLSU::load_eew(f_readMem, VectorRegField, emul_num, emul_denom, eew_bytes, evl, pVLEN >> 3, pVd, pMSTART, pVSTART, pVm, eew_bytes);
   return (0);
 }
 
@@ -263,6 +284,28 @@ uint8_t etiss_vstore_encoded_unitstride(
   };
 
   VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVs3, pMSTART, pVSTART, pVm, eew_bytes);
+
+  return (0);
+}
+
+uint8_t etiss_vstore_mask(
+  ETISS_CPU* const pCpu,
+  ETISS_System* const pSystem,
+  void * const * const plugin_pointers,
+  uint8_t* pV, uint8_t pVm, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART)
+{
+  uint8_t* VectorRegField = pV;
+  std::function<void(size_t, uint8_t*, size_t)> f_writeMem = [pSystem, pCpu](size_t addr, uint8_t* buff, size_t len) {
+    (*(pSystem->dwrite))(pSystem->handle, pCpu, addr, buff, len);
+  };
+
+  static constexpr auto eew_bytes = 1;
+  static constexpr auto emul_num = 1;
+  static constexpr auto emul_denom = 1;
+  // evl = ceil(vl / 8)
+  auto const evl = (pVL + 7) / 8;
+
+  VLSU::store_eew(f_writeMem, VectorRegField, emul_num, emul_denom, eew_bytes, evl, pVLEN >> 3, pVs3, pMSTART, pVSTART, pVm, eew_bytes);
 
   return (0);
 }

--- a/src/jitlibs/softvector/etiss_softvector.cpp
+++ b/src/jitlibs/softvector/etiss_softvector.cpp
@@ -20,6 +20,8 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 //#include "softvector.h"
+#include <algorithm>
+
 #include "base/base.hpp"
 #include "lsu/lsu.hpp"
 
@@ -136,8 +138,8 @@ uint8_t etiss_vload_segment_unitstride(
   uint64_t _moffset = pMSTART;
   auto const eew_bytes = pEEW >> 3U;
 
-  for(int i = 0; i < pNF; ++i){
-    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + (i*_z_emul/_n_emul), _moffset, _vstart, pVm, pNF * eew_bytes);
+  for(size_t i = 0; i < pNF; ++i){
+    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + std::max(i, i * (_z_emul/_n_emul)), _moffset, _vstart, pVm, pNF * eew_bytes);
     _moffset += eew_bytes;
     // _vstart = 0;
   }
@@ -168,9 +170,9 @@ uint8_t etiss_vload_segment_stride(
   uint64_t _moffset = pMSTART;
   auto const eew_bytes = pEEW >> 3U;
 
-  for(int i = 0; i < pNF; ++i){
+  for(size_t i = 0; i < pNF; ++i){
     _moffset = pMSTART + i * (eew_bytes);
-    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + (i*_z_emul/_n_emul), _moffset, _vstart, pVm, pSTRIDE);
+    VLSU::load_eew(f_readMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVd + std::max(i, i * (_z_emul/_n_emul)), _moffset, _vstart, pVm, pSTRIDE);
     // _vstart = 0;
   }
   return (0);
@@ -205,8 +207,8 @@ uint8_t etiss_vload_segment_index(
                                  .masked = !pVm };
 
   uint64_t _moffset = pMSTART;
-  for(int i = 0; i < pNF; ++i){
-    VLSU::load_indices(f_readMem, VectorRegField, v_instr_info, pVd, pVs2, pMSTART, pEEW);
+  for(size_t i = 0; i < pNF; ++i){
+    VLSU::load_indices(f_readMem, VectorRegField, v_instr_info, pVd + std::max(i, i * (_z_emul/_n_emul)), pVs2, pMSTART, pEEW);
     _moffset += pEEW >> 3;
   }
   return (0);
@@ -316,8 +318,8 @@ uint8_t etiss_vstore_segment_unitstride(
 
   uint16_t _vstart = pVSTART;
   uint64_t _moffset = pMSTART;
-  for(int i = 0; i< pNF; ++i){
-    VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVs3 + (i * _z_emul / _n_emul), _moffset, _vstart, pVm, pNF * eew_bytes);
+  for(size_t i = 0; i < pNF; ++i){
+    VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN/8, pVs3 + std::max(i, (i * _z_emul / _n_emul)), _moffset, _vstart, pVm, pNF * eew_bytes);
     _moffset += eew_bytes;
     // TODO: Why reset _vstart?
     // _vstart = 0;
@@ -355,15 +357,15 @@ uint8_t etiss_vstore_segment_stride(
   // including the case where the byte stride is such that segments overlap in memory."
   // For now, we change order depending on positive/negative stride.
   if (pStride < 0){
-    for(int i = 0; i < pNF; ++i) {
-      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVs3 + (i * _z_emul / _n_emul), _moffset, _vstart, pVm, pStride);
+    for(size_t i = 0; i < pNF; ++i) {
+      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVs3 + std::max(i, (i * _z_emul / _n_emul)), _moffset, _vstart, pVm, pStride);
       _moffset += eew_bytes;
     }
   }
   else{
-    for(int i = pNF - 1; i >= 0; --i) {
-      _moffset = pMSTART + (i * eew_bytes);
-      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVs3 + (i * _z_emul / _n_emul), _moffset, _vstart, pVm, pStride);
+    for(size_t i = pNF; i > 0; --i) {
+      _moffset = pMSTART + ((i - 1) * eew_bytes);
+      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, eew_bytes, pVL, pVLEN / 8, pVs3 + std::max((i - 1), ((i - 1) * _z_emul / _n_emul)), _moffset, _vstart, pVm, pStride);
     }
   }
   return (0);
@@ -397,8 +399,11 @@ uint8_t etiss_vstore_segment_index(
                                  .start_element = pVSTART,
                                  .masked = !pVm };
 
-
-  VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3, pVs2, pMSTART, pEEW);
+  for (size_t i = 0; i < pNF; i++)
+  {
+    VLSU::store_indices(f_writeMem, VectorRegField, v_instr_info, pVs3 + + std::max(i, (i * _z_emul / _n_emul)), pVs2, pMSTART, pEEW);
+  }
+  
 
   return (0);
 }

--- a/src/jitlibs/softvector/etiss_softvector.cpp
+++ b/src/jitlibs/softvector/etiss_softvector.cpp
@@ -219,7 +219,7 @@ uint8_t etiss_vstore_segment_stride(
   ETISS_System* const pSystem,
   void * const * const plugin_pointers,
   uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride)
+  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride)
 {
   VTYPE::VTYPE _vt(pVTYPE);
   uint64_t _z_emul = pEEW*_vt._z_lmul;
@@ -236,11 +236,26 @@ uint8_t etiss_vstore_segment_stride(
 
   uint16_t _vstart = pVSTART;
   uint64_t _moffset = pMSTART;
-  for(int i = 0; i< pNF; ++i){
-    _moffset = pMSTART + i*pEEW/8;
-    VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd + (i*_z_emul/_n_emul), _moffset, _vstart, pVm, 0);
-    _moffset+= (pVL-_vstart)*pEEW/8;
-    _vstart = 0;
+
+  // Memory order problem: 
+  // Which stores come first? According to the spec: 
+  // "Accesses to the fields within each segment can occur in any order, 
+  // including the case where the byte stride is such that segments overlap in memory."
+  // For now, we change order depending on positive/negative stride.
+  if (pStride < 0){
+    for(int i = 0; i < pNF; i++) {
+      // _moffset = pMSTART + i*pEEW/8;
+      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd + (i*_z_emul/_n_emul), _moffset, _vstart, pVm, pStride);
+      _moffset+= pEEW/8;
+      // _vstart = 0;
+    }
+  }
+  else{
+    for(int i = pNF - 1; i >= 0; i--) {
+      _moffset = pMSTART + i * (pEEW / 8);
+      VLSU::store_eew(f_writeMem, VectorRegField, _z_emul, _n_emul, pEEW/8, pVL, pVLEN/8, pVd + (i * (_z_emul / _n_emul)), _moffset, _vstart, pVm, pStride);
+      // _vstart = 0;
+    }
   }
   return (0);
 }

--- a/src/jitlibs/softvector/libsoftvector.h
+++ b/src/jitlibs/softvector/libsoftvector.h
@@ -28,149 +28,151 @@ struct ETISS_System;
 struct ETISS_CPU;
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/* Vector Loads/Stores Helpers*/
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Load encoded (unitstride) from memory to target vector (-group)
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vload_encoded_unitstride(
-	ETISS_CPU* const pCpu,				//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
-	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
-  void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
-	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART);
+    /* Vector Loads/Stores Helpers*/
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Load encoded (unitstride) from memory to target vector (-group)
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vload_encoded_unitstride(
+        ETISS_CPU *const pCpu,       //!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
+        ETISS_System *const pSystem, //!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
+        void *const *const plugin_pointers, //!>[inout] Pointers to ETISS plugins. Unused
+        uint8_t *pV,                        //!<[inout] Vector register field as local memory
+        uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL,
+        uint64_t pMSTART);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Load encoded (strided) from memory to target vector (-group)
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vload_encoded_stride(
-	ETISS_CPU* const pCpu,				//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
-	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
-  	void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
-	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pSTRIDE);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Load encoded (strided) from memory to target vector (-group)
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vload_encoded_stride(
+        ETISS_CPU *const pCpu,       //!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
+        ETISS_System *const pSystem, //!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
+        void *const *const plugin_pointers, //!>[inout] Pointers to ETISS plugins. Unused
+        uint8_t *pV,                        //!<[inout] Vector register field as local memory
+        uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL,
+        uint64_t pMSTART, int16_t pSTRIDE);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Load encoded (indexed) from memory to target vector (-group)
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vload_encoded_index(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Load encoded (indexed) from memory to target vector (-group)
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vload_encoded_index(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                      void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                      uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL,
+                                      uint64_t pMSTART, uint8_t pVs2);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Load seqgmented (unitstride) from memory to target vector (-group)
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vload_segment_unitstride(
-	ETISS_CPU* const pCpu,				//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
-	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
-  void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
-	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Load seqgmented (unitstride) from memory to target vector (-group)
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vload_segment_unitstride(
+        ETISS_CPU *const pCpu,       //!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
+        ETISS_System *const pSystem, //!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
+        void *const *const plugin_pointers, //!>[inout] Pointers to ETISS plugins. Unused
+        uint8_t *pV,                        //!<[inout] Vector register field as local memory
+        uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN,
+        uint16_t pVL, uint64_t pMSTART);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Load encoded (strided) from memory to target vector (-group)
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vload_segment_stride(
-	ETISS_CPU* const pCpu,				//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
-	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
-  void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
-	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pSTRIDE);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Load encoded (strided) from memory to target vector (-group)
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vload_segment_stride(
+        ETISS_CPU *const pCpu,       //!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
+        ETISS_System *const pSystem, //!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
+        void *const *const plugin_pointers, //!>[inout] Pointers to ETISS plugins. Unused
+        uint8_t *pV,                        //!<[inout] Vector register field as local memory
+        uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN,
+        uint16_t pVL, uint64_t pMSTART, int16_t pSTRIDE);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Load segmented (indexed) from memory to target vector (-group)
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vload_segment_index(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Load segmented (indexed) from memory to target vector (-group)
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vload_segment_index(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                      void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                      uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN,
+                                      uint16_t pVL, uint64_t pMSTART, uint8_t pVs2);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Load whole registers
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vload_registers(
-	ETISS_CPU* const pCpu,				//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
-	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
-  void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
-	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint64_t pMSTART);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Load whole registers
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vload_registers(
+        ETISS_CPU *const pCpu,       //!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
+        ETISS_System *const pSystem, //!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
+        void *const *const plugin_pointers, //!>[inout] Pointers to ETISS plugins. Unused
+        uint8_t *pV,                        //!<[inout] Vector register field as local memory
+        uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN,
+        uint64_t pMSTART);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Store encoded (unitstride) source vector (-group) to memory
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vstore_encoded_unitstride(
-	ETISS_CPU* const pCpu,				//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
-	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
-  void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
-	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Store encoded (unitstride) source vector (-group) to memory
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vstore_encoded_unitstride(
+        ETISS_CPU *const pCpu,       //!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
+        ETISS_System *const pSystem, //!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
+        void *const *const plugin_pointers, //!>[inout] Pointers to ETISS plugins. Unused
+        uint8_t *pV,                        //!<[inout] Vector register field as local memory
+        uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL,
+        uint64_t pMSTART);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Store encoded (strided) source vector (-group) to memory
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vstore_encoded_stride(
-	ETISS_CPU* const pCpu,				//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
-	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
-  void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
-	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Store encoded (strided) source vector (-group) to memory
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vstore_encoded_stride(
+        ETISS_CPU *const pCpu,       //!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
+        ETISS_System *const pSystem, //!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
+        void *const *const plugin_pointers, //!>[inout] Pointers to ETISS plugins. Unused
+        uint8_t *pV,                        //!<[inout] Vector register field as local memory
+        uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL,
+        uint64_t pMSTART, int16_t pStride);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Load encoded (indexed) from memory to target vector (-group)
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vstore_encoded_index(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t  pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Load encoded (indexed) from memory to target vector (-group)
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vstore_encoded_index(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                       void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                       uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL,
+                                       uint64_t pMSTART, uint8_t pVs2);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Store segmented (unitstride) source vector (-group) to memory
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vstore_segment_unitstride(
-	ETISS_CPU* const pCpu,				//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
-	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
-  void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
-	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Store segmented (unitstride) source vector (-group) to memory
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vstore_segment_unitstride(
+        ETISS_CPU *const pCpu,       //!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
+        ETISS_System *const pSystem, //!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
+        void *const *const plugin_pointers, //!>[inout] Pointers to ETISS plugins. Unused
+        uint8_t *pV,                        //!<[inout] Vector register field as local memory
+        uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN,
+        uint16_t pVL, uint64_t pMSTART);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Store segmented (strided) source vector (-group) to memory
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vstore_segment_stride(
-	ETISS_CPU* const pCpu,				//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
-	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
-  void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
-	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Store segmented (strided) source vector (-group) to memory
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vstore_segment_stride(
+        ETISS_CPU *const pCpu,       //!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
+        ETISS_System *const pSystem, //!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
+        void *const *const plugin_pointers, //!>[inout] Pointers to ETISS plugins. Unused
+        uint8_t *pV,                        //!<[inout] Vector register field as local memory
+        uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN,
+        uint16_t pVL, uint64_t pMSTART, int16_t pStride);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Store segmented (indexed) source vector (-group) to memory
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vstore_segment_index(
-  ETISS_CPU* const pCpu,
-  ETISS_System* const pSystem,
-  void * const * const plugin_pointers,
-  uint8_t* pV,
-  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Store segmented (indexed) source vector (-group) to memory
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vstore_segment_index(ETISS_CPU *const pCpu, ETISS_System *const pSystem,
+                                       void *const *const plugin_pointers, uint8_t *pV, uint16_t pVTYPE, uint8_t pVm,
+                                       uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN,
+                                       uint16_t pVL, uint64_t pMSTART, uint8_t pVs2);
 
-//////////////////////////////////////////////////////////////////////////////////////
-/// \brief Store whole registers to memory
-/// \return 0 if no exception triggered, else 1
-uint8_t etiss_vstore_registers(
-	ETISS_CPU* const pCpu,					//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
-	ETISS_System* const pSystem,			//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
-  	void * const * const plugin_pointers,  	//!>[inout] Pointers to ETISS plugins. Unused
-	uint8_t* pV,							//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t pVm, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint64_t pMSTART);
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// \brief Store whole registers to memory
+    /// \return 0 if no exception triggered, else 1
+    uint8_t etiss_vstore_registers(
+        ETISS_CPU *const pCpu,       //!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
+        ETISS_System *const pSystem, //!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
+        void *const *const plugin_pointers, //!>[inout] Pointers to ETISS plugins. Unused
+        uint8_t *pV,                        //!<[inout] Vector register field as local memory
+        uint16_t pVTYPE, uint8_t pVm, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint64_t pMSTART);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/jitlibs/softvector/libsoftvector.h
+++ b/src/jitlibs/softvector/libsoftvector.h
@@ -40,7 +40,7 @@ uint8_t etiss_vload_encoded_unitstride(
 	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
   void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
 	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t  pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART);
+	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART);
 
 //////////////////////////////////////////////////////////////////////////////////////
 /// \brief Load encoded (strided) from memory to target vector (-group)
@@ -48,9 +48,19 @@ uint8_t etiss_vload_encoded_unitstride(
 uint8_t etiss_vload_encoded_stride(
 	ETISS_CPU* const pCpu,				//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
 	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
-  void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
+  	void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
 	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t  pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pSTRIDE);
+	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pSTRIDE);
+
+//////////////////////////////////////////////////////////////////////////////////////
+/// \brief Load encoded (indexed) from memory to target vector (-group)
+/// \return 0 if no exception triggered, else 1
+uint8_t etiss_vload_encoded_index(
+  ETISS_CPU* const pCpu,
+  ETISS_System* const pSystem,
+  void * const * const plugin_pointers,
+  uint8_t* pV,
+  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2);
 
 //////////////////////////////////////////////////////////////////////////////////////
 /// \brief Load seqgmented (unitstride) from memory to target vector (-group)
@@ -73,6 +83,16 @@ uint8_t etiss_vload_segment_stride(
 	uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pSTRIDE);
 
 //////////////////////////////////////////////////////////////////////////////////////
+/// \brief Load segmented (indexed) from memory to target vector (-group)
+/// \return 0 if no exception triggered, else 1
+uint8_t etiss_vload_segment_index(
+  ETISS_CPU* const pCpu,
+  ETISS_System* const pSystem,
+  void * const * const plugin_pointers,
+  uint8_t* pV,
+  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2);
+
+//////////////////////////////////////////////////////////////////////////////////////
 /// \brief Store encoded (unitstride) source vector (-group) to memory
 /// \return 0 if no exception triggered, else 1
 uint8_t etiss_vstore_encoded_unitstride(
@@ -80,7 +100,7 @@ uint8_t etiss_vstore_encoded_unitstride(
 	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
   void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
 	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART);
+	uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART);
 
 //////////////////////////////////////////////////////////////////////////////////////
 /// \brief Store encoded (strided) source vector (-group) to memory
@@ -90,7 +110,17 @@ uint8_t etiss_vstore_encoded_stride(
 	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
   void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
 	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride);
+	uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride);
+
+//////////////////////////////////////////////////////////////////////////////////////
+/// \brief Load encoded (indexed) from memory to target vector (-group)
+/// \return 0 if no exception triggered, else 1
+uint8_t etiss_vstore_encoded_index(
+  ETISS_CPU* const pCpu,
+  ETISS_System* const pSystem,
+  void * const * const plugin_pointers,
+  uint8_t* pV,
+  uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t  pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2);
 
 //////////////////////////////////////////////////////////////////////////////////////
 /// \brief Store segmented (unitstride) source vector (-group) to memory
@@ -100,7 +130,7 @@ uint8_t etiss_vstore_segment_unitstride(
 	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
   void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
 	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART);
+	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART);
 
 //////////////////////////////////////////////////////////////////////////////////////
 /// \brief Store segmented (strided) source vector (-group) to memory
@@ -110,7 +140,17 @@ uint8_t etiss_vstore_segment_stride(
 	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
   void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
 	uint8_t* pV,						//!<[inout] Vector register field as local memory
-	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride);
+	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, int16_t pStride);
+
+//////////////////////////////////////////////////////////////////////////////////////
+/// \brief Store segmented (indexed) source vector (-group) to memory
+/// \return 0 if no exception triggered, else 1
+uint8_t etiss_vstore_segment_index(
+  ETISS_CPU* const pCpu,
+  ETISS_System* const pSystem,
+  void * const * const plugin_pointers,
+  uint8_t* pV,
+  uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/jitlibs/softvector/libsoftvector.h
+++ b/src/jitlibs/softvector/libsoftvector.h
@@ -93,6 +93,16 @@ uint8_t etiss_vload_segment_index(
   uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2);
 
 //////////////////////////////////////////////////////////////////////////////////////
+/// \brief Load whole registers
+/// \return 0 if no exception triggered, else 1
+uint8_t etiss_vload_registers(
+	ETISS_CPU* const pCpu,				//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
+	ETISS_System* const pSystem,		//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
+  void * const * const plugin_pointers,  //!>[inout] Pointers to ETISS plugins. Unused
+	uint8_t* pV,						//!<[inout] Vector register field as local memory
+	uint16_t pVTYPE, uint8_t  pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVd, uint16_t pVSTART, uint16_t pVLEN, uint64_t pMSTART);
+
+//////////////////////////////////////////////////////////////////////////////////////
 /// \brief Store encoded (unitstride) source vector (-group) to memory
 /// \return 0 if no exception triggered, else 1
 uint8_t etiss_vstore_encoded_unitstride(
@@ -151,6 +161,16 @@ uint8_t etiss_vstore_segment_index(
   void * const * const plugin_pointers,
   uint8_t* pV,
   uint16_t pVTYPE, uint8_t pVm, uint16_t pEEW, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint16_t pVL, uint64_t pMSTART, uint8_t pVs2);
+
+//////////////////////////////////////////////////////////////////////////////////////
+/// \brief Store whole registers to memory
+/// \return 0 if no exception triggered, else 1
+uint8_t etiss_vstore_registers(
+	ETISS_CPU* const pCpu,					//!<[inout] Pointer to ETISS_CPU structure. Supports Vector register field
+	ETISS_System* const pSystem,			//!<[inout] Pointer to ETISS_System structure. Supports databus/memory acesses
+  	void * const * const plugin_pointers,  	//!>[inout] Pointers to ETISS plugins. Unused
+	uint8_t* pV,							//!<[inout] Vector register field as local memory
+	uint16_t pVTYPE, uint8_t pVm, uint8_t pNF, uint8_t pVs3, uint16_t pVSTART, uint16_t pVLEN, uint64_t pMSTART);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
### Description

This PR fixes/implements the ETISS side of vector loads/stores, except fault-only-first loads. Additionally, the RV32IMACFDV architecture was added to include the full set of Zve32f instructions, again, excluding fault-only-first loads.